### PR TITLE
Add error for regex with no named groups

### DIFF
--- a/plugin/builtin/parser/regex.go
+++ b/plugin/builtin/parser/regex.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/observiq/carbon/entry"
+	"github.com/observiq/carbon/errors"
 	"github.com/observiq/carbon/plugin"
 	"github.com/observiq/carbon/plugin/helper"
 )
@@ -35,6 +36,19 @@ func (c RegexParserConfig) Build(context plugin.BuildContext) (plugin.Plugin, er
 	r, err := regexp.Compile(c.Regex)
 	if err != nil {
 		return nil, fmt.Errorf("compiling regex: %s", err)
+	}
+
+	namedCaptureGroups := 0
+	for _, groupName := range r.SubexpNames() {
+		if groupName != "" {
+			namedCaptureGroups++
+		}
+	}
+	if namedCaptureGroups == 0 {
+		return nil, errors.NewError(
+			"no named capture groups in regex pattern",
+			"use named capture groups like '^(?P<my_key>.*)$' to specify the key name for the parsed field",
+		)
 	}
 
 	regexParser := &RegexParser{

--- a/plugin/builtin/parser/regex_test.go
+++ b/plugin/builtin/parser/regex_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/observiq/carbon/plugin/helper"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 func newFakeRegexParser() (*RegexParser, *testutil.Plugin) {
@@ -99,36 +98,43 @@ func TestBuildParserRegex(t *testing.T) {
 					},
 				},
 			},
-			Regex: ".*",
+			Regex: "(?P<all>.*)",
 		}
 	}
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicRegexParser()
-		buildContext := plugin.BuildContext{
-			Logger: zaptest.NewLogger(t).Sugar(),
-		}
-		_, err := c.Build(buildContext)
+		_, err := c.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
 	})
 
 	t.Run("MissingRegexField", func(t *testing.T) {
 		c := newBasicRegexParser()
 		c.Regex = ""
-		buildContext := plugin.BuildContext{
-			Logger: zaptest.NewLogger(t).Sugar(),
-		}
-		_, err := c.Build(buildContext)
+		_, err := c.Build(testutil.NewBuildContext(t))
 		require.Error(t, err)
 	})
 
 	t.Run("InvalidRegexField", func(t *testing.T) {
 		c := newBasicRegexParser()
 		c.Regex = "())()"
-		buildContext := plugin.BuildContext{
-			Logger: zaptest.NewLogger(t).Sugar(),
-		}
-		_, err := c.Build(buildContext)
+		_, err := c.Build(testutil.NewBuildContext(t))
 		require.Error(t, err)
+	})
+
+	t.Run("NoNamedGroups", func(t *testing.T) {
+		c := newBasicRegexParser()
+		c.Regex = ".*"
+		_, err := c.Build(testutil.NewBuildContext(t))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no named capture groups")
+	})
+
+	t.Run("NoNamedGroups", func(t *testing.T) {
+		c := newBasicRegexParser()
+		c.Regex = "(.*)"
+		_, err := c.Build(testutil.NewBuildContext(t))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no named capture groups")
 	})
 }


### PR DESCRIPTION
## Description of Changes

A common error is to use a regex pattern without any named capture groups. This errors out in that case because it's almost guaranteed to be unintended. 

Sample error message:
```json
{
  "level": "error",
  "timestamp": "2020-07-09T10:10:32.855-0400",
  "message": "Failed to start carbon log agent",
  "error": {
    "description": "build pipeline: build plugins: no named capture groups in regex pattern",
    "suggestion": "use named capture groups like '^(?P<my_key>.*)$' to specify the key name for the parsed field",
    "details": {
      "plugin_id": "$.rp",
      "plugin_type": "regex_parser"
    }
  }
}
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CI passes
