### PR TITLE
Warn when preserve is set, but the original value would be overwritten

### DIFF
--- a/plugin/helper/parser.go
+++ b/plugin/helper/parser.go
@@ -34,6 +34,14 @@ func (c ParserConfig) Build(context plugin.BuildContext) (ParserPlugin, error) {
 		c.ParseTo.FieldInterface = entry.NewRecordField()
 	}
 
+	if c.ParseFrom.String() == c.ParseTo.String() && c.Preserve {
+		transformerPlugin.Warnw(
+			"preserve is true, but parse_to is set to the same field as parse_from, "+
+				"which will cause the original value to be overwritten",
+			"plugin_id", c.PluginID,
+		)
+	}
+
 	parserPlugin := ParserPlugin{
 		TransformerPlugin: transformerPlugin,
 		ParseFrom:         c.ParseFrom,


### PR DESCRIPTION
## Description of Changes

When preserve is set, users expect the original value to be available after parsing. However, in some cases, writing the results of our parse step will overwrite the original value. An example is when we are parsing from root, and writing the parsed fields to the root level. In these cases, this PR adds a warning message that briefly explains the situation. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
