### PR TITLE
Fix crash when using absolute paths for log files on Windows

### DIFF
--- a/commands/logging.go
+++ b/commands/logging.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func init() {
+	registerWindowsSink()
+}
+
+func newDefaultLoggerAt(level zapcore.Level, path string) *zap.SugaredLogger {
+	logCfg := zap.NewProductionConfig()
+	logCfg.Level = zap.NewAtomicLevelAt(level)
+	logCfg.Sampling.Initial = 5
+	logCfg.Sampling.Thereafter = 100
+	logCfg.EncoderConfig.CallerKey = ""
+	logCfg.EncoderConfig.StacktraceKey = ""
+	logCfg.EncoderConfig.TimeKey = "timestamp"
+	logCfg.EncoderConfig.MessageKey = "message"
+	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+
+	if path != "" {
+		logCfg.OutputPaths = []string{pathToURI(path)}
+	}
+
+	baseLogger, err := logCfg.Build()
+	if err != nil {
+		panic(err)
+	}
+	return baseLogger.Sugar()
+}
+
+func pathToURI(path string) string {
+	switch runtime.GOOS {
+	case "windows":
+		return "winfile:///" + filepath.ToSlash(path)
+	default:
+		return filepath.ToSlash(path)
+	}
+}
+
+var registerSyncsOnce sync.Once
+
+func registerWindowsSink() {
+	registerSyncsOnce.Do(func() {
+		if runtime.GOOS == "windows" {
+			err := zap.RegisterSink("winfile", newWinFileSink)
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+}
+
+func newWinFileSink(u *url.URL) (zap.Sink, error) {
+	return os.OpenFile(u.Path[1:], os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -111,25 +111,6 @@ func runRoot(command *cobra.Command, _ []string, flags *RootFlags) {
 	profilingWg.Wait()
 }
 
-func newDefaultLoggerAt(level zapcore.Level, path string) *zap.SugaredLogger {
-	logCfg := zap.NewProductionConfig()
-	logCfg.Level = zap.NewAtomicLevelAt(level)
-	logCfg.Sampling.Initial = 5
-	logCfg.Sampling.Thereafter = 100
-	logCfg.EncoderConfig.CallerKey = ""
-	logCfg.EncoderConfig.StacktraceKey = ""
-	logCfg.EncoderConfig.TimeKey = "timestamp"
-	logCfg.EncoderConfig.MessageKey = "message"
-	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-
-	if path != "" {
-		logCfg.OutputPaths = []string{path}
-	}
-
-	baseLogger, _ := logCfg.Build()
-	return baseLogger.Sugar()
-}
-
 func startProfiling(ctx context.Context, flags *RootFlags, logger *zap.SugaredLogger) *sync.WaitGroup {
 	wg := &sync.WaitGroup{}
 


### PR DESCRIPTION
## Description of Changes

Fix a bug where using absolute paths for the windows log file path causes a crash. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
