### PR TITLE
Skip move file test on Windows

### DIFF
--- a/entry/entry.go
+++ b/entry/entry.go
@@ -7,11 +7,11 @@ import (
 
 // Entry is a flexible representation of log data associated with a timestamp.
 type Entry struct {
-	Timestamp time.Time         `json:"timestamp" yaml:"timestamp"`
-	Severity  Severity          `json:"severity" yaml:"severity"`
-	Tags      []string          `json:"tags,omitempty"      yaml:"tags,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"    yaml:"labels,omitempty"`
-	Record    interface{}       `json:"record"    yaml:"record"`
+	Timestamp time.Time         `json:"timestamp"        yaml:"timestamp"`
+	Severity  Severity          `json:"severity"         yaml:"severity"`
+	Tags      []string          `json:"tags,omitempty"   yaml:"tags,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Record    interface{}       `json:"record"           yaml:"record"`
 }
 
 // New will create a new log entry with current timestamp and an empty record.

--- a/plugin/builtin/input/file/file_test.go
+++ b/plugin/builtin/input/file/file_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -331,6 +332,9 @@ func TestFileSource_MultiFileSimple(t *testing.T) {
 }
 
 func TestFileSource_MoveFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Moving files while open is unsupported on Windows")
+	}
 	t.Parallel()
 	source, logReceived := newTestFileSource(t)
 	tempDir := testutil.NewTempDir(t)


### PR DESCRIPTION
## Description of Changes

This test was intermittently failing, and due to the Windows file lock,
     moving files that are open is not a supported operation anyways.

Also reformats some struct tags slightly.

## Description of Changes

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
