### PR TITLE
google_cloud plugin will by default use the project to which gcp credentials belong

### DIFF
--- a/.circleci/testdata/benchmark.yaml
+++ b/.circleci/testdata/benchmark.yaml
@@ -7,6 +7,5 @@ pipeline:
 
   - id: google_cloud
     type: google_cloud_output
-    project_id: bplogagent-benchmark
     # credentials found automatically on gce instance
-    # TODO: replace project with carbon-benchmark?
+    # project_id taken from credentials by default

--- a/docs/plugins/google_cloud_output.md
+++ b/docs/plugins/google_cloud_output.md
@@ -9,7 +9,7 @@ The `google_cloud_output` plugin will send entries to Google Cloud Logging.
 | `id`               | required | A unique identifier for the plugin                                                                     |
 | `credentials`      |          | The JSON-formatted credentials for the logs writer service account                                     |
 | `credentials_file` |          | A path to a file containing the JSON-formatted credentials                                             |
-| `project_id`       | required | The Google Cloud project ID the logs should be sent to                                                 |
+| `project_id`       |          | The Google Cloud project ID the logs should be sent to. Defaults to project_id found in credentials    |
 | `log_name_field`   |          | A [field](/docs/types/field.md) for the log name on the entry. Log name defaults to `default` if unset |
 | `labels_field`     |          | A [field](/docs/types/field.md) for the labels object on the log entry                                 |
 | `severity_field`   |          | A [field](/docs/types/field.md) for the severity on the log entry                                      |

--- a/plugin/builtin/output/google_cloud.go
+++ b/plugin/builtin/output/google_cloud.go
@@ -49,10 +49,6 @@ func (c GoogleCloudOutputConfig) Build(buildContext plugin.BuildContext) (plugin
 		return nil, err
 	}
 
-	if c.ProjectID == "" {
-		return nil, errors.New("missing required configuration option project_id")
-	}
-
 	newBuffer, err := c.BufferConfig.Build()
 	if err != nil {
 		return nil, err
@@ -132,6 +128,10 @@ func (p *GoogleCloudOutput) Start() error {
 		if err != nil {
 			return fmt.Errorf("get default credentials: %s", err)
 		}
+	}
+
+	if p.projectID == "" {
+		p.projectID = credentials.ProjectID
 	}
 
 	options := make([]option.ClientOption, 0, 2)


### PR DESCRIPTION
This can still be overridden using the project_id config field

## Description of Changes

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
