### PR TITLE
Install improvements

### DIFF
--- a/scripts/unix-install.sh
+++ b/scripts/unix-install.sh
@@ -439,6 +439,11 @@ generate_config()
 # This will the create a config file with an example pipeline.
 create_config_file()
 {
+  # Don't overwrite a config file that already exists
+  if [ -f "$1" ] ; then
+    return
+  fi
+
   cat << EOF > "$1"
 # pipeline:
 #   - id: example_input

--- a/scripts/windows-install.ps1
+++ b/scripts/windows-install.ps1
@@ -417,29 +417,6 @@ new-module -name LogAgentInstall -scriptblock {
     Remove-Indent
   }
 
-  # This will ensure that any previous installations are removed.
-  function Assert-CleanInstall {
-    Show-Header 'Ensuring Clean Installation'
-    Add-Indent
-    Remove-AgentService
-
-    if ( Test-Path "$script:agent_home" ) {
-      try {
-        Show-ColorText 'Previous installation detected at ' '' "$script:agent_home" DarkCyan '. Removing...'
-        Get-ChildItem "$script:agent_home" -Recurse | Remove-Item -Recurse -Force -ErrorAction Stop
-        Show-ColorText 'Previous installation files removed.'
-      }
-      catch {
-        Exit-Error $MyInvocation.ScriptLineNumber "Could not remove $script:agent_home: $($_.Exception.Message)" 'Please ensure you have permission to remove this directory and its files.'
-      }
-    }
-    else {
-      Show-ColorText 'Clean installation path detected. (' '' "$script:agent_home" DarkCyan ')'
-    }
-    Complete
-    Remove-Indent
-  }
-
   # This will remove the agent service.
   function Remove-AgentService {
     $service = Get-Service $SERVICE_NAME -ErrorAction SilentlyContinue
@@ -618,7 +595,7 @@ new-module -name LogAgentInstall -scriptblock {
         Test-Prerequisites
         Set-InstallVariables
         Set-Permissions
-        Assert-CleanInstall
+        Remove-AgentService
         Get-CarbonBinary
         New-AgentConfig
         New-AgentService

--- a/scripts/windows-install.ps1
+++ b/scripts/windows-install.ps1
@@ -485,6 +485,9 @@ new-module -name LogAgentInstall -scriptblock {
 
   # This will write the agent config.
   function Write-Config {
+    # Skip overwriting the config file if it already exists
+    if (Test-Path $args) { return }
+
     @"
 # pipeline:
 #   - id: example_input


### PR DESCRIPTION
## Description of Changes

When installing a over an existing version, we were clobbering any config file that was already installed. This skips overwriting a config file if it already exists. 

Additionally, we were hitting an issue where writing the binary fails when the service is running because the file is in use. Now, we stop the service before downloading the binary. 

Tested on Windows, Darwin, and Centos 7

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
