### PR TITLE
Add carbon to path during unix installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Link `carbon` into `/usr/local/bin` so it's available on most users' `PATH` ([PR28](https://github.com/observIQ/carbon/pull/28))
+
 ## [0.9.1] - 2020-07-13
 ### Added
 - More specific warning and error messages for common configuration issues ([PR12](https://github.com/observIQ/carbon/pull/12),[PR13](https://github.com/observIQ/carbon/pull/13),[PR14](https://github.com/observIQ/carbon/pull/14))

--- a/scripts/unix-install.sh
+++ b/scripts/unix-install.sh
@@ -415,6 +415,7 @@ install_package()
 
   info "Setting permissions..."
   chmod +x "$agent_binary"
+  ln -s "$agent_binary" "/usr/local/bin/$BINARY_NAME"
   succeeded
 
   success "Carbon installation complete!"


### PR DESCRIPTION
## Description of Changes

Links Carbon into `/usr/local/bin` so that it's available without a full path. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
