### PR TITLE
Add FileNameField option to file input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Link `carbon` into `/usr/local/bin` so it's available on most users' `PATH` ([PR28](https://github.com/observIQ/carbon/pull/28))
+- New parameter `file_name_path` to the file input plugin for cases when just the file name is needed
 
 ## [0.9.1] - 2020-07-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Link `carbon` into `/usr/local/bin` so it's available on most users' `PATH` ([PR28](https://github.com/observIQ/carbon/pull/28))
 - New parameter `file_name_path` to the file input plugin for cases when just the file name is needed
+### Changed
+- Renamed `path_field` to `file_path_field` in the file input plugin
 
 ## [0.9.1] - 2020-07-13
 ### Added

--- a/docs/plugins/file_input.md
+++ b/docs/plugins/file_input.md
@@ -4,18 +4,19 @@ The `file_input` plugin reads logs from files. It will place the lines read into
 
 ### Configuration Fields
 
-| Field           | Default  | Description                                                                                                         |
-| ---             | ---      | ---                                                                                                                 |
-| `id`            | required | A unique identifier for the plugin                                                                                  |
-| `output`        | required | The connected plugin(s) that will receive all outbound entries                                                      |
-| `include`       | required | A list of file glob patterns that match the file paths to be read                                                   |
-| `exclude`       | []       | A list of file glob patterns to exclude from reading                                                                |
-| `poll_interval` | 200ms    | The duration between filesystem polls                                                                               |
-| `multiline`     |          | A `multiline` configuration block. See below for details                                                            |
-| `write_to`      | $        | A [field](/docs/types/field.md) that will be set to the log message                                                 |
-| `path_field`    |          | A [field](/docs/types/field.md) that will be set to the path of the file the entry was read from                    |
-| `start_at`      | `end`    | At startup, where to start reading logs from the file. Options are `beginning` or `end`                             |
-| `max_log_size`  | 1048576  | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory. |
+| Field             | Default  | Description                                                                                                         |
+| ---               | ---      | ---                                                                                                                 |
+| `id`              | required | A unique identifier for the plugin                                                                                  |
+| `output`          | required | The connected plugin(s) that will receive all outbound entries                                                      |
+| `include`         | required | A list of file glob patterns that match the file paths to be read                                                   |
+| `exclude`         | []       | A list of file glob patterns to exclude from reading                                                                |
+| `poll_interval`   | 200ms    | The duration between filesystem polls                                                                               |
+| `multiline`       |          | A `multiline` configuration block. See below for details                                                            |
+| `write_to`        | $        | A [field](/docs/types/field.md) that will be set to the log message                                                 |
+| `path_field`      |          | A [field](/docs/types/field.md) that will be set to the path of the file the entry was read from                    |
+| `file_name_field` |          | A [field](/docs/types/field.md) that will be set to the name of the file the entry was read from                    |
+| `start_at`        | `end`    | At startup, where to start reading logs from the file. Options are `beginning` or `end`                             |
+| `max_log_size`    | 1048576  | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory. |
 
 Note that by default, no logs will be read unless the monitored file is actively being written to because `start_at` defaults to `end`.
 

--- a/docs/plugins/file_input.md
+++ b/docs/plugins/file_input.md
@@ -13,7 +13,7 @@ The `file_input` plugin reads logs from files. It will place the lines read into
 | `poll_interval`   | 200ms    | The duration between filesystem polls                                                                               |
 | `multiline`       |          | A `multiline` configuration block. See below for details                                                            |
 | `write_to`        | $        | A [field](/docs/types/field.md) that will be set to the log message                                                 |
-| `path_field`      |          | A [field](/docs/types/field.md) that will be set to the path of the file the entry was read from                    |
+| `file_path_field` |          | A [field](/docs/types/field.md) that will be set to the path of the file the entry was read from                    |
 | `file_name_field` |          | A [field](/docs/types/field.md) that will be set to the name of the file the entry was read from                    |
 | `start_at`        | `end`    | At startup, where to start reading logs from the file. Options are `beginning` or `end`                             |
 | `max_log_size`    | 1048576  | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory. |

--- a/plugin/builtin/input/file/file.go
+++ b/plugin/builtin/input/file/file.go
@@ -33,7 +33,7 @@ type InputConfig struct {
 
 	PollInterval  *plugin.Duration `json:"poll_interval,omitempty"   yaml:"poll_interval,omitempty"`
 	Multiline     *MultilineConfig `json:"multiline,omitempty"       yaml:"multiline,omitempty"`
-	PathField     *entry.Field     `json:"path_field,omitempty"      yaml:"path_field,omitempty"`
+	FilePathField *entry.Field     `json:"path_field,omitempty"      yaml:"path_field,omitempty"`
 	FileNameField *entry.Field     `json:"file_name_field,omitempty" yaml:"file_name_field,omitempty"`
 	StartAt       string           `json:"start_at,omitempty"        yaml:"start_at,omitempty"`
 	MaxLogSize    int              `json:"max_log_size,omitempty"    yaml:"max_log_size,omitempty"`
@@ -101,7 +101,7 @@ func (c InputConfig) Build(context plugin.BuildContext) (plugin.Plugin, error) {
 		SplitFunc:        splitFunc,
 		PollInterval:     pollInterval,
 		persist:          helper.NewScopedDBPersister(context.Database, c.ID()),
-		PathField:        c.PathField,
+		FilePathField:    c.FilePathField,
 		FileNameField:    c.FileNameField,
 		runningFiles:     make(map[string]struct{}),
 		fileUpdateChan:   make(chan fileUpdateMessage, 10),
@@ -153,7 +153,7 @@ type InputPlugin struct {
 
 	Include       []string
 	Exclude       []string
-	PathField     *entry.Field
+	FilePathField *entry.Field
 	FileNameField *entry.Field
 	PollInterval  time.Duration
 	SplitFunc     bufio.SplitFunc
@@ -273,7 +273,7 @@ func (f *InputPlugin) checkFile(ctx context.Context, path string, firstCheck boo
 	go func(ctx context.Context, path string, offset, lastSeenSize int64) {
 		defer f.readerWg.Done()
 		messenger := f.newFileUpdateMessenger(path)
-		err := ReadToEnd(ctx, path, offset, lastSeenSize, messenger, f.SplitFunc, f.PathField, f.FileNameField, f.InputPlugin, f.MaxLogSize)
+		err := ReadToEnd(ctx, path, offset, lastSeenSize, messenger, f.SplitFunc, f.FilePathField, f.FileNameField, f.InputPlugin, f.MaxLogSize)
 		if err != nil {
 			f.Warnw("Failed to read log file", zap.Error(err))
 		}

--- a/plugin/builtin/input/file/file.go
+++ b/plugin/builtin/input/file/file.go
@@ -31,11 +31,12 @@ type InputConfig struct {
 	Include []string `json:"include,omitempty" yaml:"include,omitempty"`
 	Exclude []string `json:"exclude,omitempty" yaml:"exclude,omitempty"`
 
-	PollInterval *plugin.Duration `json:"poll_interval,omitempty" yaml:"poll_interval,omitempty"`
-	Multiline    *MultilineConfig `json:"multiline,omitempty"     yaml:"multiline,omitempty"`
-	PathField    *entry.Field     `json:"path_field,omitempty"    yaml:"path_field,omitempty"`
-	StartAt      string           `json:"start_at,omitempty"      yaml:"start_at,omitempty"`
-	MaxLogSize   int              `json:"max_log_size,omitempty"  yaml:"max_log_size,omitempty"`
+	PollInterval  *plugin.Duration `json:"poll_interval,omitempty"   yaml:"poll_interval,omitempty"`
+	Multiline     *MultilineConfig `json:"multiline,omitempty"       yaml:"multiline,omitempty"`
+	PathField     *entry.Field     `json:"path_field,omitempty"      yaml:"path_field,omitempty"`
+	FileNameField *entry.Field     `json:"file_name_field,omitempty" yaml:"file_name_field,omitempty"`
+	StartAt       string           `json:"start_at,omitempty"        yaml:"start_at,omitempty"`
+	MaxLogSize    int              `json:"max_log_size,omitempty"    yaml:"max_log_size,omitempty"`
 }
 
 // MultilineConfig is the configuration a multiline operation
@@ -101,6 +102,7 @@ func (c InputConfig) Build(context plugin.BuildContext) (plugin.Plugin, error) {
 		PollInterval:     pollInterval,
 		persist:          helper.NewScopedDBPersister(context.Database, c.ID()),
 		PathField:        c.PathField,
+		FileNameField:    c.FileNameField,
 		runningFiles:     make(map[string]struct{}),
 		fileUpdateChan:   make(chan fileUpdateMessage, 10),
 		fingerprintBytes: 1000,
@@ -149,12 +151,13 @@ func (c InputConfig) getSplitFunc() (bufio.SplitFunc, error) {
 type InputPlugin struct {
 	helper.InputPlugin
 
-	Include      []string
-	Exclude      []string
-	PathField    *entry.Field
-	PollInterval time.Duration
-	SplitFunc    bufio.SplitFunc
-	MaxLogSize   int
+	Include       []string
+	Exclude       []string
+	PathField     *entry.Field
+	FileNameField *entry.Field
+	PollInterval  time.Duration
+	SplitFunc     bufio.SplitFunc
+	MaxLogSize    int
 
 	persist helper.Persister
 
@@ -270,7 +273,7 @@ func (f *InputPlugin) checkFile(ctx context.Context, path string, firstCheck boo
 	go func(ctx context.Context, path string, offset, lastSeenSize int64) {
 		defer f.readerWg.Done()
 		messenger := f.newFileUpdateMessenger(path)
-		err := ReadToEnd(ctx, path, offset, lastSeenSize, messenger, f.SplitFunc, f.PathField, f.InputPlugin, f.MaxLogSize)
+		err := ReadToEnd(ctx, path, offset, lastSeenSize, messenger, f.SplitFunc, f.PathField, f.FileNameField, f.InputPlugin, f.MaxLogSize)
 		if err != nil {
 			f.Warnw("Failed to read log file", zap.Error(err))
 		}

--- a/plugin/builtin/input/file/file_test.go
+++ b/plugin/builtin/input/file/file_test.go
@@ -61,7 +61,7 @@ func TestFileSource_Build(t *testing.T) {
 	t.Parallel()
 	mockOutput := testutil.NewMockPlugin("mock")
 
-	pathField := entry.NewRecordField("testpath")
+	filePathField := entry.NewRecordField("testpath")
 
 	basicConfig := func() *InputConfig {
 		return &InputConfig{
@@ -80,7 +80,7 @@ func TestFileSource_Build(t *testing.T) {
 			PollInterval: &plugin.Duration{
 				Duration: 10 * time.Millisecond,
 			},
-			PathField: &pathField,
+			FilePathField: &filePathField,
 		}
 	}
 
@@ -97,7 +97,7 @@ func TestFileSource_Build(t *testing.T) {
 			func(t *testing.T, f *InputPlugin) {
 				require.Equal(t, f.OutputPlugins[0], mockOutput)
 				require.Equal(t, f.Include, []string{"/var/log/testpath.*"})
-				require.Equal(t, f.PathField, &pathField)
+				require.Equal(t, f.FilePathField, &filePathField)
 				require.Equal(t, f.PollInterval, 10*time.Millisecond)
 			},
 		},
@@ -196,7 +196,7 @@ func TestFileSource_AddFields(t *testing.T) {
 	tempDir := testutil.NewTempDir(t)
 	source.Include = []string{fmt.Sprintf("%s/*", tempDir)}
 	pf := entry.NewLabelField("path")
-	source.PathField = &pf
+	source.FilePathField = &pf
 	fnf := entry.NewLabelField("file_name")
 	source.FileNameField = &fnf
 

--- a/plugin/builtin/input/file/read_to_end.go
+++ b/plugin/builtin/input/file/read_to_end.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ReadToEnd will read entries from a file and send them to the outputs of an input plugin
-func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFileSize int64, messenger fileUpdateMessenger, splitFunc bufio.SplitFunc, pathField, fileNameField *entry.Field, inputPlugin helper.InputPlugin, maxLogSize int) error {
+func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFileSize int64, messenger fileUpdateMessenger, splitFunc bufio.SplitFunc, filePathField, fileNameField *entry.Field, inputPlugin helper.InputPlugin, maxLogSize int) error {
 	defer messenger.FinishedReading()
 
 	select {
@@ -60,7 +60,7 @@ func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFile
 	// advanced since last cycle, read the rest of the file as an entry
 	defer func() {
 		if pos < stat.Size() && pos == startOffset && lastSeenFileSize == stat.Size() {
-			readRemaining(ctx, file, pos, stat.Size(), messenger, inputPlugin, pathField, fileNameField)
+			readRemaining(ctx, file, pos, stat.Size(), messenger, inputPlugin, filePathField, fileNameField)
 		}
 	}()
 
@@ -81,8 +81,8 @@ func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFile
 
 		message := scanner.Text()
 		e := inputPlugin.NewEntry(message)
-		if pathField != nil {
-			e.Set(*pathField, path)
+		if filePathField != nil {
+			e.Set(*filePathField, path)
 		}
 		if fileNameField != nil {
 			e.Set(*fileNameField, filepath.Base(file.Name()))
@@ -93,7 +93,7 @@ func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFile
 }
 
 // readRemaining will read the remaining characters in a file as a log entry.
-func readRemaining(ctx context.Context, file *os.File, filePos int64, fileSize int64, messenger fileUpdateMessenger, inputPlugin helper.InputPlugin, pathField, fileNameField *entry.Field) {
+func readRemaining(ctx context.Context, file *os.File, filePos int64, fileSize int64, messenger fileUpdateMessenger, inputPlugin helper.InputPlugin, filePathField, fileNameField *entry.Field) {
 	_, err := file.Seek(filePos, 0)
 	if err != nil {
 		inputPlugin.Errorf("failed to seek to read last log entry")
@@ -108,8 +108,8 @@ func readRemaining(ctx context.Context, file *os.File, filePos int64, fileSize i
 	}
 
 	e := inputPlugin.NewEntry(string(msgBuf[:n]))
-	if pathField != nil {
-		e.Set(*pathField, file.Name())
+	if filePathField != nil {
+		e.Set(*filePathField, file.Name())
 	}
 	if fileNameField != nil {
 		e.Set(*fileNameField, filepath.Base(file.Name()))


### PR DESCRIPTION
## Description of Changes

Adds `file_name_field` argument to the file input plugin. This sets a field to just the basename of the path, which is more useful in some cases like tags than the full path, which would otherwise have to be parsed with regex. 

It appears that `path_field` was removed at some point, so this also adds that back in. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
