### PR TITLE
Journalctl in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:bionic
 RUN mkdir -p /carbon_home/plugins
 ENV CARBON_HOME=/carbon_home
 RUN echo "pipeline:\n" >> /carbon_home/config.yaml
+RUN apt-get update && apt-get install -y systemd
 
 COPY ./artifacts/carbon_linux_amd64 /carbon_home/carbon
 ENTRYPOINT /carbon_home/carbon \


### PR DESCRIPTION
## Description of Changes

Add systemd to docker container so it has access to `journald`. 

This adds a lot of overhead, so it may be necessary to figure out how to minimize this dependency in the future. 

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
