### PR TITLE
Fix uses of path_field from bad merge

### DIFF
--- a/examples/k8s/daemonset.yaml
+++ b/examples/k8s/daemonset.yaml
@@ -44,7 +44,7 @@ data:
         include:
           - /var/log/containers/*
         write_to: message
-        path_field: path
+        file_path_field: path
         output: path_parser
 
       - id: path_parser

--- a/plugin/builtin/input/file/file.go
+++ b/plugin/builtin/input/file/file.go
@@ -33,7 +33,7 @@ type InputConfig struct {
 
 	PollInterval  *plugin.Duration `json:"poll_interval,omitempty"   yaml:"poll_interval,omitempty"`
 	Multiline     *MultilineConfig `json:"multiline,omitempty"       yaml:"multiline,omitempty"`
-	FilePathField *entry.Field     `json:"path_field,omitempty"      yaml:"path_field,omitempty"`
+	FilePathField *entry.Field     `json:"file_path_field,omitempty"      yaml:"file_path_field,omitempty"`
 	FileNameField *entry.Field     `json:"file_name_field,omitempty" yaml:"file_name_field,omitempty"`
 	StartAt       string           `json:"start_at,omitempty"        yaml:"start_at,omitempty"`
 	MaxLogSize    int              `json:"max_log_size,omitempty"    yaml:"max_log_size,omitempty"`


### PR DESCRIPTION
## Description of Changes

A bad merge left the tags on `FilePathField` to be just `path_field` still. Also fixes a reference left in the daemonset config. 

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
