### PR TITLE
Make journald emit map[string]interface{}

### DIFF
--- a/plugin/builtin/input/journald_test.go
+++ b/plugin/builtin/input/journald_test.go
@@ -63,7 +63,7 @@ func TestInputJournald(t *testing.T) {
 	err = journaldInput.Start()
 	require.NoError(t, err)
 
-	expected := map[string]string{
+	expected := map[string]interface{}{
 		"_BOOT_ID":                   "c4fa36de06824d21835c05ff80c54468",
 		"_CAP_EFFECTIVE":             "0",
 		"_TRANSPORT":                 "journal",


### PR DESCRIPTION
## Description of Changes

It turns out our `entry.Field` doesn't handle iterating through `map[string]string` well. We ran into this because the `journald` plugin emits `map[string]string`. This PR changes the `journald` input to be more in line with the other plugins so that it emits a `map[string]interface{}`.

This seems to be part of a larger recurring issue with the types that are allowed in our pipeline. We should really consider locking down the types that are allowed into the record in the first place. It's impossible to handle every type, and if we don't have any standards, it's unclear what is and is not expected to be handled by each of the downstream plugins. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
