### PR TITLE
Add support for alternative encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Add support for multiple encodings in the file input plugin
+
 ## [0.9.2] - 2020-07-13
 ### Added
 - Link `carbon` into `/usr/local/bin` so it's available on most users' `PATH` ([PR28](https://github.com/observIQ/carbon/pull/28))

--- a/docs/plugins/file_input.md
+++ b/docs/plugins/file_input.md
@@ -16,6 +16,7 @@ The `file_input` plugin reads logs from files. It will place the lines read into
 | `file_path_field` |          | A [field](/docs/types/field.md) that will be set to the path of the file the entry was read from                    |
 | `file_name_field` |          | A [field](/docs/types/field.md) that will be set to the name of the file the entry was read from                    |
 | `start_at`        | `end`    | At startup, where to start reading logs from the file. Options are `beginning` or `end`                             |
+| `encoding`        | `nop`    | The encoding of the file being read. See the list of supported encodings below for available options                |
 | `max_log_size`    | 1048576  | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory. |
 
 Note that by default, no logs will be read unless the monitored file is actively being written to because `start_at` defaults to `end`.
@@ -26,6 +27,20 @@ If set, the `multiline` configuration block instructs the `file_input` plugin to
 
 The `multiline` configuration block must contain exactly one of `line_start_pattern` or `line_end_pattern`. These are regex patterns that
 match either the beginning of a new log entry, or the end of a log entry.
+
+### Supported encodings
+
+| Key        | Description
+| ---        | ---                                                              |
+| `nop`      | No encoding validation. Treats the file as a stream of raw bytes |
+| `utf-8`    | UTF-8 encoding                                                   |
+| `utf-16le` | UTF-16 encoding with little-endian byte order                    |
+| `utf-16be` | UTF-16 encoding with little-endian byte order                    |
+| `ascii`    | ASCII encoding                                                   |
+| `big5`     | The Big5 Chinese character encoding                              |
+
+Other less common encodings are supported on a best-effort basis. See [https://www.iana.org/assignments/character-sets/character-sets.xhtml](https://www.iana.org/assignments/character-sets/character-sets.xhtml) for other encodings available.
+
 
 ### Example Configurations
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c // indirect
+	golang.org/x/text v0.3.2
 	golang.org/x/tools v0.0.0-20200513201620-d5fe73897c97 // indirect
 	gonum.org/v1/gonum v0.6.2
 	google.golang.org/api v0.20.0

--- a/plugin/builtin/input/file/read_to_end.go
+++ b/plugin/builtin/input/file/read_to_end.go
@@ -10,10 +10,24 @@ import (
 	"github.com/observiq/carbon/entry"
 	"github.com/observiq/carbon/errors"
 	"github.com/observiq/carbon/plugin/helper"
+	"go.uber.org/zap"
+	"golang.org/x/text/encoding"
 )
 
 // ReadToEnd will read entries from a file and send them to the outputs of an input plugin
-func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFileSize int64, messenger fileUpdateMessenger, splitFunc bufio.SplitFunc, filePathField, fileNameField *entry.Field, inputPlugin helper.InputPlugin, maxLogSize int) error {
+func ReadToEnd(
+	ctx context.Context,
+	path string,
+	startOffset int64,
+	lastSeenFileSize int64,
+	messenger fileUpdateMessenger,
+	splitFunc bufio.SplitFunc,
+	filePathField *entry.Field,
+	fileNameField *entry.Field,
+	inputPlugin helper.InputPlugin,
+	maxLogSize int,
+	encoding encoding.Encoding,
+) error {
 	defer messenger.FinishedReading()
 
 	select {
@@ -56,11 +70,16 @@ func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFile
 	}
 	scanner.Split(scanFunc)
 
+	decoder := encoding.NewDecoder()
+
+	// Make a large, reusable buffer for transforming
+	decodeBuffer := make([]byte, 16384)
+
 	// If we're not at the end of the file, and we haven't
 	// advanced since last cycle, read the rest of the file as an entry
 	defer func() {
 		if pos < stat.Size() && pos == startOffset && lastSeenFileSize == stat.Size() {
-			readRemaining(ctx, file, pos, stat.Size(), messenger, inputPlugin, filePathField, fileNameField)
+			readRemaining(ctx, file, pos, stat.Size(), messenger, inputPlugin, filePathField, fileNameField, decoder, decodeBuffer)
 		}
 	}()
 
@@ -79,8 +98,13 @@ func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFile
 			return scanner.Err()
 		}
 
-		message := scanner.Text()
-		e := inputPlugin.NewEntry(message)
+		decoder.Reset()
+		nDst, _, err := decoder.Transform(decodeBuffer, scanner.Bytes(), true)
+		if err != nil {
+			return err
+		}
+
+		e := inputPlugin.NewEntry(string(decodeBuffer[:nDst]))
 		if filePathField != nil {
 			e.Set(*filePathField, path)
 		}
@@ -93,7 +117,7 @@ func ReadToEnd(ctx context.Context, path string, startOffset int64, lastSeenFile
 }
 
 // readRemaining will read the remaining characters in a file as a log entry.
-func readRemaining(ctx context.Context, file *os.File, filePos int64, fileSize int64, messenger fileUpdateMessenger, inputPlugin helper.InputPlugin, filePathField, fileNameField *entry.Field) {
+func readRemaining(ctx context.Context, file *os.File, filePos int64, fileSize int64, messenger fileUpdateMessenger, inputPlugin helper.InputPlugin, filePathField, fileNameField *entry.Field, encoder *encoding.Decoder, decodeBuffer []byte) {
 	_, err := file.Seek(filePos, 0)
 	if err != nil {
 		inputPlugin.Errorf("failed to seek to read last log entry")
@@ -106,8 +130,13 @@ func readRemaining(ctx context.Context, file *os.File, filePos int64, fileSize i
 		inputPlugin.Errorf("failed to read trailing log")
 		return
 	}
+	encoder.Reset()
+	nDst, _, err := encoder.Transform(decodeBuffer, msgBuf, true)
+	if err != nil {
+		inputPlugin.Errorw("failed to decode trailing log", zap.Error(err))
+	}
 
-	e := inputPlugin.NewEntry(string(msgBuf[:n]))
+	e := inputPlugin.NewEntry(string(decodeBuffer[:nDst]))
 	if filePathField != nil {
 		e.Set(*filePathField, file.Name())
 	}


### PR DESCRIPTION
## Description of Changes

This commit adds support for all encodings supported by the
`x/text/encoding` package. This can be configured with the new
`encoding` parameter of the file input.

A limitation of the current implementation is that it does not respect
the BOM in UTF16, so users will have to explicitly choose `utf-16le` or
`utf16-be`

## Description of Changes

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
