### PR TITLE
Add -f flag to symbolic link

### DIFF
--- a/scripts/unix-install.sh
+++ b/scripts/unix-install.sh
@@ -419,7 +419,7 @@ install_package()
 
   info "Setting permissions..."
   chmod +x "$agent_binary"
-  ln -s "$agent_binary" "/usr/local/bin/$BINARY_NAME"
+  ln -sf "$agent_binary" "/usr/local/bin/$BINARY_NAME"
   succeeded
 
   success "Carbon installation complete!"


### PR DESCRIPTION
## Description of Changes

Adds the -f flag so that, on update or reinstall, the install script
doesn't fail because the link already exists.

## Description of Changes

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
