### PR TITLE
Add docker hub publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,24 @@ jobs:
           command: |
             ghr -t ${GHI_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/
 
+  publish-docker-release:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: "Publish Release on Docker Hub"
+          command: |
+            docker_tag=$(echo ${CIRCLE_TAG} | cut -b2- )
+            docker build -t observiq/carbon:${docker_tag} .
+            docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_TOKEN}
+            docker push observiq/carbon:${docker_tag}
+            docker tag observiq/carbon:${docker_tag} observiq/carbon:latest
+            docker push observiq/carbon:latest
+
   test-linux:
     executor: golang
     resource_class: large
@@ -363,6 +381,14 @@ workflows:
             - test-macos
             - test-windows
       - publish-github-release:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+.*/
+      - publish-docker-release:
           requires:
             - build
           filters:


### PR DESCRIPTION
## Description of Changes

Whenever a release is created, an image will be built and pushed to docker hub with as both `latest` and the version number, such as `0.9.3`. This has been tested with a pre-release. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
