### PR TITLE
Add configurable timeout to k8s_metadata_decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Configurable `timeout` parameter for the `k8s_metadata_decorator`
+
+
 ## [0.9.4] - 2020-07-21
 - Allow omitting `id`, defaulting to plugin type if unique within namespace
 - Allow omitting `output`, defaulting to the next operator in the pipeline if valid

--- a/docs/operators/k8s_metadata_decorator.md
+++ b/docs/operators/k8s_metadata_decorator.md
@@ -4,13 +4,14 @@ The `k8s_metadata_decorator` operator adds labels and annotations to the entry u
 
 ### Configuration Fields
 
-| Field             | Default                  | Description                                                                                     |
-| ---               | ---                      | ---                                                                                             |
-| `id`              | `k8s_metadata_decorator` | A unique identifier for the operator                                                            |
-| `output`          | Next in pipeline         | The connected operator(s) that will receive all outbound entries                                |
-| `namespace_field` | `namespace`              | A [field](/docs/types/field.md) that contains the k8s namespace associated with the log entry   |
-| `pod_name_field`  | `pod_name`               | A [field](/docs/types/field.md) that contains the k8s pod name associated with the log entry    |
-| `cache_ttl`       | 10m                      | A [duration](/docs/types/duration.md) indicating the time it takes for a cached entry to expire |
+| Field             | Default                  | Description                                                                                                |
+| ---               | ---                      | ---                                                                                                        |
+| `id`              | `k8s_metadata_decorator` | A unique identifier for the operator                                                                       |
+| `output`          | Next in pipeline         | The connected operator(s) that will receive all outbound entries                                           |
+| `namespace_field` | `namespace`              | A [field](/docs/types/field.md) that contains the k8s namespace associated with the log entry              |
+| `pod_name_field`  | `pod_name`               | A [field](/docs/types/field.md) that contains the k8s pod name associated with the log entry               |
+| `cache_ttl`       | 10m                      | A [duration](/docs/types/duration.md) indicating the time it takes for a cached entry to expire            |
+| `timeout`         | 10s                      | A [duration](/docs/types/duration.md) indicating how long to wait for the API to respond before timing out |
 
 ### Example Configurations
 

--- a/operator/builtin/input/tcp_test.go
+++ b/operator/builtin/input/tcp_test.go
@@ -1,6 +1,8 @@
 package input
 
 import (
+	"fmt"
+	"math/rand"
 	"net"
 	"testing"
 	"time"
@@ -30,8 +32,10 @@ func TestTCPInput(t *testing.T) {
 	}
 
 	t.Run("Simple", func(t *testing.T) {
+		port := rand.Int()%16000 + 49152
+		address := fmt.Sprintf("127.0.0.1:%d", port)
 		cfg := basicTCPInputConfig()
-		cfg.ListenAddress = "127.0.0.1:64001"
+		cfg.ListenAddress = address
 
 		buildContext := testutil.NewBuildContext(t)
 		newOperator, err := cfg.Build(buildContext)
@@ -50,7 +54,7 @@ func TestTCPInput(t *testing.T) {
 		require.NoError(t, err)
 		defer tcpInput.Stop()
 
-		conn, err := net.Dial("tcp", "127.0.0.1:64001")
+		conn, err := net.Dial("tcp", address)
 		require.NoError(t, err)
 		defer conn.Close()
 

--- a/operator/builtin/input/udp_test.go
+++ b/operator/builtin/input/udp_test.go
@@ -1,6 +1,8 @@
 package input
 
 import (
+	"fmt"
+	"math/rand"
 	"net"
 	"testing"
 	"time"
@@ -30,8 +32,10 @@ func TestUDPInput(t *testing.T) {
 	}
 
 	t.Run("Simple", func(t *testing.T) {
+		port := rand.Int()%16000 + 49152
+    address := fmt.Sprintf("127.0.0.1:%d", port)
 		cfg := basicUDPInputConfig()
-		cfg.ListenAddress = "127.0.0.1:63001"
+		cfg.ListenAddress = address
 
 		buildContext := testutil.NewBuildContext(t)
 		newOperator, err := cfg.Build(buildContext)
@@ -52,7 +56,7 @@ func TestUDPInput(t *testing.T) {
 		require.NoError(t, err)
 		defer udpInput.Stop()
 
-		conn, err := net.Dial("udp", "127.0.0.1:63001")
+		conn, err := net.Dial("udp", address)
 		require.NoError(t, err)
 		defer conn.Close()
 

--- a/operator/builtin/transformer/k8s_metadata_decorator_test.go
+++ b/operator/builtin/transformer/k8s_metadata_decorator_test.go
@@ -53,6 +53,7 @@ func TestK8sMetadataDecoratorBuildDefault(t *testing.T) {
 		podNameField:   entry.NewRecordField("pod_name"),
 		namespaceField: entry.NewRecordField("namespace"),
 		cacheTTL:       10 * time.Minute,
+		timeout:        10 * time.Second,
 	}
 
 	operator, err := cfg.Build(testutil.NewBuildContext(t))


### PR DESCRIPTION
## Description of Changes

The original timeout of 5 seconds was occasionally being hit in my testing, so instead of just increasing it, it seemed best to make it configurable. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
