### PR TITLE
Add start_at parameter to journald input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Configurable `timeout` parameter for the `k8s_metadata_decorator`
-
+- New parameter `start_at` for journald input
 
 ## [0.9.4] - 2020-07-21
 - Allow omitting `id`, defaulting to plugin type if unique within namespace

--- a/docs/operators/journald_input.md
+++ b/docs/operators/journald_input.md
@@ -15,7 +15,7 @@ The `journald_input` operator will use the `__REALTIME_TIMESTAMP` field of the j
 | `directory` |                  | A directory containing journal files to read entries from                                        |
 | `files`     |                  | A list of journal files to read entries from                                                     |
 | `write_to`  | $                | A [field](/docs/types/field.md) that will be set to the path of the file the entry was read from |
-
+| `start_at`  | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`          |
 
 
 ### Example Configurations

--- a/operator/builtin/input/journald.go
+++ b/operator/builtin/input/journald.go
@@ -27,6 +27,7 @@ func init() {
 func NewJournaldInputConfig(operatorID string) *JournaldInputConfig {
 	return &JournaldInputConfig{
 		InputConfig: helper.NewInputConfig(operatorID, "journald_input"),
+		StartAt:     "end",
 	}
 }
 
@@ -36,6 +37,7 @@ type JournaldInputConfig struct {
 
 	Directory *string  `json:"directory,omitempty" yaml:"directory,omitempty"`
 	Files     []string `json:"files,omitempty"     yaml:"files,omitempty"`
+	StartAt   string   `json:"start_at,omitempty"  yaml:"start_at,omitempty"`
 }
 
 // Build will build a journald input operator from the supplied configuration
@@ -55,6 +57,14 @@ func (c JournaldInputConfig) Build(buildContext operator.BuildContext) (operator
 
 	// Continue watching logs until cancelled
 	args = append(args, "--follow")
+
+	switch c.StartAt {
+	case "end":
+	case "beginning":
+		args = append(args, "--no-tail")
+	default:
+		return nil, fmt.Errorf("invalid value '%s' for parameter 'start_at'", c.StartAt)
+	}
 
 	switch {
 	case c.Directory != nil:


### PR DESCRIPTION
## Description of Changes

Adds a configurable `start_at` parameter to the journald input plugin, which previously could only start at the end. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
