### PR TITLE
Fix issue with default outputs in plugins

### DIFF
--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -52,8 +52,9 @@ func NewTestDatabase(t *testing.T) *bbolt.DB {
 // NewBuildContext will return a new build context for testing
 func NewBuildContext(t *testing.T) operator.BuildContext {
 	return operator.BuildContext{
-		Database: NewTestDatabase(t),
-		Logger:   zaptest.NewLogger(t).Sugar(),
+		PluginRegistry: make(operator.PluginRegistry),
+		Database:       NewTestDatabase(t),
+		Logger:         zaptest.NewLogger(t).Sugar(),
 	}
 }
 

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -620,6 +620,7 @@ func TestFileSource_FileMovedWhileOff_SmallFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	waitForMessage(t, logReceived, log1)
+	time.Sleep(50 * time.Millisecond)
 
 	// Restart the source
 	err = source.Stop()


### PR DESCRIPTION
## Description of Changes

With the initial implementation of default outputs, omitting the output
for a plugin operator would cause the output variable in the templates
to be empty, defaulting to the next operator in the plugin pipeline.
This was not caught originally because in tests, only the last operator
in a plugin pipeline used the output variable. This correctly sets the
output template variable before rendering the plugin pipeline.

Additionally, this cleans up a couple of tests. 

## Description of Changes

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
