### PR TITLE
Encoding buffer resizing

### DIFF
--- a/operator/builtin/input/file/positional_scanner.go
+++ b/operator/builtin/input/file/positional_scanner.go
@@ -1,0 +1,33 @@
+package file
+
+import (
+	"bufio"
+	"io"
+)
+
+type PositionalScanner struct {
+	pos int64
+	*bufio.Scanner
+}
+
+func NewPositionalScanner(r io.Reader, maxLogSize int, startOffset int64, splitFunc bufio.SplitFunc) *PositionalScanner {
+	ps := &PositionalScanner{
+		pos:     startOffset,
+		Scanner: bufio.NewScanner(r),
+	}
+
+	buf := make([]byte, 0, 16384)
+	ps.Scanner.Buffer(buf, maxLogSize)
+
+	scanFunc := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		advance, token, err = splitFunc(data, atEOF)
+		ps.pos += int64(advance)
+		return
+	}
+	ps.Scanner.Split(scanFunc)
+	return ps
+}
+
+func (ps *PositionalScanner) Pos() int64 {
+	return ps.pos
+}

--- a/operator/builtin/input/file/read_to_end.go
+++ b/operator/builtin/input/file/read_to_end.go
@@ -29,8 +29,6 @@ func ReadToEnd(
 	maxLogSize int,
 	encoding encoding.Encoding,
 ) error {
-	defer messenger.FinishedReading()
-
 	select {
 	case <-ctx.Done():
 		return nil

--- a/operator/builtin/input/file/read_to_end.go
+++ b/operator/builtin/input/file/read_to_end.go
@@ -58,16 +58,7 @@ func ReadToEnd(
 		return fmt.Errorf("seek file: %s", err)
 	}
 
-	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 0, 16384)
-	scanner.Buffer(buf, maxLogSize)
-	pos := startOffset
-	scanFunc := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
-		advance, token, err = splitFunc(data, atEOF)
-		pos += int64(advance)
-		return
-	}
-	scanner.Split(scanFunc)
+	scanner := NewPositionalScanner(file, maxLogSize, startOffset, splitFunc)
 
 	// Make a large, reusable buffer for transforming
 	decoder := encoding.NewDecoder()
@@ -113,24 +104,24 @@ func ReadToEnd(
 		}
 
 		emit(scanner.Bytes())
-		messenger.SetOffset(pos)
+		messenger.SetOffset(scanner.Pos())
 	}
 
 	// If we're not at the end of the file, and we haven't
 	// advanced since last cycle, read the rest of the file as an entry
-	if pos < stat.Size() && pos == startOffset && lastSeenFileSize == stat.Size() {
-		_, err := file.Seek(pos, 0)
+	if scanner.Pos() < stat.Size() && scanner.Pos() == startOffset && lastSeenFileSize == stat.Size() {
+		_, err := file.Seek(scanner.Pos(), 0)
 		if err != nil {
 			return errors.Wrap(err, "seeking for trailing entry")
 		}
 
-		msgBuf := make([]byte, stat.Size()-pos)
+		msgBuf := make([]byte, stat.Size()-scanner.Pos())
 		n, err := file.Read(msgBuf)
 		if err != nil {
 			return errors.Wrap(err, "reading trailing entry")
 		}
 		emit(msgBuf[:n])
-		messenger.SetOffset(pos + int64(n))
+		messenger.SetOffset(scanner.Pos() + int64(n))
 	}
 
 	return nil


### PR DESCRIPTION
## Description of Changes

Fixes the `short destination buffer` error introduced by the multiple encoding support by doubling its capacity each time we hit that error. 

Additionally, made a bunch of incremental refactors:
- Pulled out duplicated code into the `emit` closure
- Moved the read to end logic out of the defer statement for proper error handling and more linear logic flow
- Simplified channel operations and goroutine wait logic, fixing a bug with unclean `Stop()` in the process (which should help stabilize our tests a bit)
- Pulled the nasty scanner stuff into its own object, which isolates the confusing parts

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
