### PR TITLE
Remove deprecated labels_field

### DIFF
--- a/docs/operators/google_cloud_output.md
+++ b/docs/operators/google_cloud_output.md
@@ -11,7 +11,6 @@ The `google_cloud_output` operator will send entries to Google Cloud Logging.
 | `credentials_file` |                       | A path to a file containing the JSON-formatted credentials                                             |
 | `project_id`       |                       | The Google Cloud project ID the logs should be sent to. Defaults to project_id found in credentials    |
 | `log_name_field`   |                       | A [field](/docs/types/field.md) for the log name on the entry. Log name defaults to `default` if unset |
-| `labels_field`     |                       | A [field](/docs/types/field.md) for the labels object on the log entry                                 |
 | `severity_field`   |                       | A [field](/docs/types/field.md) for the severity on the log entry                                      |
 | `trace_field`      |                       | A [field](/docs/types/field.md) for the trace on the log entry                                         |
 | `span_id_field`    |                       | A [field](/docs/types/field.md) for the span_id on the log entry                                       |


### PR DESCRIPTION
## Description of Changes

`labels_field` was removed from the operator when we changed it so labels are automatically promoted. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
