### PR TITLE
Use go-syslog fork for longer sdid support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Fork go-syslog to support long sdnames that are not rfc5424-compliant
+
 ## [0.9.5] - 2020-07-28
 ### Added
 - Configurable `timeout` parameter for the `k8s_metadata_decorator` ([PR54](https://github.com/observIQ/carbon/pull/54))

--- a/go.mod
+++ b/go.mod
@@ -37,3 +37,5 @@ require (
 	k8s.io/apimachinery v0.18.4
 	k8s.io/client-go v0.18.4
 )
+
+replace github.com/influxdata/go-syslog/v3 => github.com/observiq/go-syslog/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
+github.com/observiq/go-syslog/v3 v3.0.1 h1:lillWZkfRqDAg1UvzDc6UeEsoLuT3fFnq+6FOf9UHW4=
+github.com/observiq/go-syslog/v3 v3.0.1/go.mod h1:9abcumkQwDUY0VgWdH6CaaJ3Ks39A7NvIelMlavPru0=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/operator/builtin/parser/syslog_test.go
+++ b/operator/builtin/parser/syslog_test.go
@@ -91,6 +91,32 @@ func TestSyslogParser(t *testing.T) {
 				"version": 1,
 			},
 		},
+		{
+			"RFC5424LongSDName",
+			func() *SyslogParserConfig {
+				cfg := basicConfig()
+				cfg.Protocol = "rfc5424"
+				return cfg
+			}(),
+			`<86>1 2015-08-05T21:58:59.693Z 192.168.2.132 SecureAuth0 23108 ID52020 [verylongsdnamethatisgreaterthan32bytes@12345 UserHostAddress="192.168.2.132"] my message`,
+			time.Date(2015, 8, 5, 21, 58, 59, 693000000, time.UTC),
+			map[string]interface{}{
+				"appname":  "SecureAuth0",
+				"facility": 10,
+				"hostname": "192.168.2.132",
+				"message":  "my message",
+				"msg_id":   "ID52020",
+				"priority": 86,
+				"proc_id":  "23108",
+				"severity": 6,
+				"structured_data": map[string]map[string]string{
+					"verylongsdnamethatisgreaterthan32bytes@12345": {
+						"UserHostAddress": "192.168.2.132",
+					},
+				},
+				"version": 1,
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Description of Changes

Point to our fork of `go-syslog`, which contains a change that accepts SDIDs that are too long to be compliant with rfc5424. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
