### PR TITLE
Trim carriage returns from TCP input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Fork go-syslog to support long sdnames that are not rfc5424-compliant
+- Reduce noise in debug messages for TCP and UDP inputs
+### Fixed
+- Trim carriage returns from TCP input
 
 ## [0.9.5] - 2020-07-28
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ install-tools:
 test:
 	go test -race -coverprofile coverage.txt -coverpkg ./... ./...
 
+.PHONY: bench
+bench:
+	go test -run=NONE -bench '.*' ./... -benchmem
+
 .PHONY: lint
 lint:
 	golangci-lint run ./...

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -1,5 +1,14 @@
 package testutil
 
+import (
+	context "context"
+
+	entry "github.com/observiq/carbon/entry"
+	"github.com/observiq/carbon/operator"
+	zap "go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
 // NewMockOperator will return a basic operator mock
 func NewMockOperator(id string) *Operator {
 	mockOutput := &Operator{}
@@ -7,4 +16,64 @@ func NewMockOperator(id string) *Operator {
 	mockOutput.On("CanProcess").Return(true)
 	mockOutput.On("CanOutput").Return(true)
 	return mockOutput
+}
+
+type FakeOutput struct {
+	Received chan *entry.Entry
+	*zap.SugaredLogger
+}
+
+func NewFakeOutput(t TestingT) *FakeOutput {
+	return &FakeOutput{
+		Received:      make(chan *entry.Entry, 100),
+		SugaredLogger: zaptest.NewLogger(t).Sugar(),
+	}
+}
+
+func (f *FakeOutput) CanOutput() bool {
+	return false
+}
+
+func (f *FakeOutput) CanProcess() bool {
+	return true
+}
+
+func (f *FakeOutput) ID() string {
+	return "benchmark"
+}
+
+// Logger provides a mock function with given fields:
+func (f *FakeOutput) Logger() *zap.SugaredLogger {
+	return f.SugaredLogger
+}
+
+// Outputs provides a mock function with given fields:
+func (f *FakeOutput) Outputs() []operator.Operator {
+	return nil
+}
+
+// Process provides a mock function with given fields: _a0, _a1
+func (f *FakeOutput) Process(ctx context.Context, entry *entry.Entry) error {
+	f.Received <- entry
+	return nil
+}
+
+// SetOutputs provides a mock function with given fields: _a0
+func (f *FakeOutput) SetOutputs(outputs []operator.Operator) error {
+	return nil
+}
+
+// Start provides a mock function with given fields:
+func (f *FakeOutput) Start() error {
+	return nil
+}
+
+// Stop provides a mock function with given fields:
+func (f *FakeOutput) Stop() error {
+	return nil
+}
+
+// Type provides a mock function with given fields:
+func (f *FakeOutput) Type() string {
+	return "fake_output"
 }

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -27,10 +27,11 @@ func NewTempDir(t *testing.T) string {
 }
 
 // NewTestDatabase will return a new database for testing
-func NewTestDatabase(t *testing.T) *bbolt.DB {
+func NewTestDatabase(t TestingT) *bbolt.DB {
 	tempDir, err := ioutil.TempDir("", "")
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf(err.Error())
+		t.FailNow()
 	}
 
 	t.Cleanup(func() {
@@ -39,7 +40,8 @@ func NewTestDatabase(t *testing.T) *bbolt.DB {
 
 	db, err := bbolt.Open(filepath.Join(tempDir, "test.db"), 0666, nil)
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf(err.Error())
+		t.FailNow()
 	}
 
 	t.Cleanup(func() {
@@ -50,7 +52,7 @@ func NewTestDatabase(t *testing.T) *bbolt.DB {
 }
 
 // NewBuildContext will return a new build context for testing
-func NewBuildContext(t *testing.T) operator.BuildContext {
+func NewBuildContext(t TestingT) operator.BuildContext {
 	return operator.BuildContext{
 		PluginRegistry: make(operator.PluginRegistry),
 		Database:       NewTestDatabase(t),
@@ -69,4 +71,26 @@ func Trim(s string) string {
 	}
 
 	return strings.Join(trimmed, "\n")
+}
+
+type TestingT interface {
+	// Logs the given message without failing the test.
+	Logf(string, ...interface{})
+
+	// Logs the given message and marks the test as failed.
+	Errorf(string, ...interface{})
+
+	// Marks the test as failed.
+	Fail()
+
+	// Returns true if the test has been marked as failed.
+	Failed() bool
+
+	// Returns the name of the test.
+	Name() string
+
+	// Marks the test as failed and stops execution of that test.
+	FailNow()
+
+	Cleanup(func())
 }

--- a/operator/builtin/input/tcp.go
+++ b/operator/builtin/input/tcp.go
@@ -4,12 +4,12 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"sync"
 
 	"github.com/observiq/carbon/operator"
 	"github.com/observiq/carbon/operator/helper"
+	"go.uber.org/zap"
 )
 
 func init() {
@@ -87,8 +87,12 @@ func (t *TCPInput) goListen(ctx context.Context) {
 		for {
 			conn, err := t.listener.AcceptTCP()
 			if err != nil {
-				t.Debugf("Exiting listener: %s", err)
-				break
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					t.Debugw("Listener accept error", zap.Error(err))
+				}
 			}
 
 			t.Debugf("Received connection: %s", conn.RemoteAddr().String())
@@ -121,31 +125,15 @@ func (t *TCPInput) goHandleMessages(ctx context.Context, conn net.Conn, cancel c
 		defer t.waitGroup.Done()
 		defer cancel()
 
-		reader := bufio.NewReaderSize(conn, 1024*64)
-		for {
-			message, err := t.readMessage(conn, reader)
-			if err != nil {
-				t.Debugf("Exiting message handler: %s", err)
-				break
-			}
-
-			entry := t.NewEntry(message)
+		scanner := bufio.NewScanner(conn)
+		for scanner.Scan() {
+			entry := t.NewEntry(scanner.Text())
 			t.Write(ctx, entry)
 		}
-	}()
-}
-
-// readMessage will read a log message from a TCP connection.
-func (t *TCPInput) readMessage(conn net.Conn, reader *bufio.Reader) (string, error) {
-	message, err := reader.ReadBytes('\n')
-	if err != nil {
-		if err == io.EOF {
-			return string(message), err
+		if err := scanner.Err(); err != nil {
+			t.Errorw("Scanner error", zap.Error(err))
 		}
-		return "", err
-	}
-
-	return string(message[:len(message)-1]), nil
+	}()
 }
 
 // Stop will stop listening for log entries over TCP.

--- a/operator/builtin/input/tcp_test.go
+++ b/operator/builtin/input/tcp_test.go
@@ -10,35 +10,17 @@ import (
 	"github.com/observiq/carbon/entry"
 	"github.com/observiq/carbon/internal/testutil"
 	"github.com/observiq/carbon/operator"
-	"github.com/observiq/carbon/operator/helper"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTCPInput(t *testing.T) {
-	basicTCPInputConfig := func() *TCPInputConfig {
-		return &TCPInputConfig{
-			InputConfig: helper.InputConfig{
-				WriteTo: entry.NewRecordField(),
-				WriterConfig: helper.WriterConfig{
-					BasicConfig: helper.BasicConfig{
-						OperatorID:   "test_id",
-						OperatorType: "tcp_input",
-					},
-					OutputIDs: []string{"test_output_id"},
-				},
-			},
-		}
-	}
-
-	t.Run("Simple", func(t *testing.T) {
-		port := rand.Int()%16000 + 49152
-		address := fmt.Sprintf("127.0.0.1:%d", port)
-		cfg := basicTCPInputConfig()
+func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
+	return func(t *testing.T) {
+		cfg := NewTCPInputConfig("test_id")
+		address := newRandListenAddress()
 		cfg.ListenAddress = address
 
-		buildContext := testutil.NewBuildContext(t)
-		newOperator, err := cfg.Build(buildContext)
+		newOperator, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -58,16 +40,73 @@ func TestTCPInput(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
-		_, err = conn.Write([]byte("message1\n"))
+		_, err = conn.Write(input)
 		require.NoError(t, err)
 
-		expectedRecord := "message1"
+		for _, expectedMessage := range expected {
+			select {
+			case entry := <-entryChan:
+				require.Equal(t, expectedMessage, entry.Record)
+			case <-time.After(time.Second):
+				require.FailNow(t, "Timed out waiting for message to be written")
+			}
+		}
+
 		select {
 		case entry := <-entryChan:
-			require.Equal(t, expectedRecord, entry.Record)
-		case <-time.After(time.Second):
-			require.FailNow(t, "Timed out waiting for message to be written")
+			require.FailNow(t, "Unexpected entry: %s", entry)
+		case <-time.After(100 * time.Millisecond):
+			return
 		}
-	})
+	}
+}
 
+func TestTcpInput(t *testing.T) {
+	t.Run("Simple", tcpInputTest([]byte("message\n"), []string{"message"}))
+	t.Run("CarriageReturn", tcpInputTest([]byte("message\r\n"), []string{"message"}))
+}
+
+func newRandListenAddress() string {
+	port := rand.Int()%16000 + 49152
+	return fmt.Sprintf("127.0.0.1:%d", port)
+}
+
+func BenchmarkTcpInput(b *testing.B) {
+	cfg := NewTCPInputConfig("test_id")
+	address := newRandListenAddress()
+	cfg.ListenAddress = address
+
+	newOperator, err := cfg.Build(testutil.NewBuildContext(b))
+	require.NoError(b, err)
+
+	fakeOutput := testutil.NewFakeOutput(b)
+	tcpInput := newOperator.(*TCPInput)
+	tcpInput.InputOperator.OutputOperators = []operator.Operator{fakeOutput}
+
+	err = tcpInput.Start()
+	require.NoError(b, err)
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := net.Dial("tcp", address)
+		require.NoError(b, err)
+		defer tcpInput.Stop()
+		defer conn.Close()
+		message := []byte("message\n")
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_, err := conn.Write(message)
+				require.NoError(b, err)
+			}
+		}
+	}()
+
+	for i := 0; i < b.N; i++ {
+		<-fakeOutput.Received
+	}
+
+	defer close(done)
 }

--- a/operator/builtin/input/udp_test.go
+++ b/operator/builtin/input/udp_test.go
@@ -1,8 +1,6 @@
 package input
 
 import (
-	"fmt"
-	"math/rand"
 	"net"
 	"testing"
 	"time"
@@ -10,35 +8,18 @@ import (
 	"github.com/observiq/carbon/entry"
 	"github.com/observiq/carbon/internal/testutil"
 	"github.com/observiq/carbon/operator"
-	"github.com/observiq/carbon/operator/helper"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-func TestUDPInput(t *testing.T) {
-	basicUDPInputConfig := func() *UDPInputConfig {
-		return &UDPInputConfig{
-			InputConfig: helper.InputConfig{
-				WriteTo: entry.NewRecordField(),
-				WriterConfig: helper.WriterConfig{
-					BasicConfig: helper.BasicConfig{
-						OperatorID:   "test_id",
-						OperatorType: "udp_input",
-					},
-					OutputIDs: []string{"test_output_id"},
-				},
-			},
-		}
-	}
-
-	t.Run("Simple", func(t *testing.T) {
-		port := rand.Int()%16000 + 49152
-    address := fmt.Sprintf("127.0.0.1:%d", port)
-		cfg := basicUDPInputConfig()
+func udpInputTest(input []byte, expected []string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		cfg := NewUDPInputConfig("test_input")
+		address := newRandListenAddress()
 		cfg.ListenAddress = address
 
-		buildContext := testutil.NewBuildContext(t)
-		newOperator, err := cfg.Build(buildContext)
+		newOperator, err := cfg.Build(testutil.NewBuildContext(t))
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -60,16 +41,70 @@ func TestUDPInput(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
-		_, err = conn.Write([]byte("message1\n"))
+		_, err = conn.Write(input)
 		require.NoError(t, err)
 
-		expectedRecord := "message1"
+		for _, expectedRecord := range expected {
+			select {
+			case entry := <-entryChan:
+				require.Equal(t, expectedRecord, entry.Record)
+			case <-time.After(time.Second):
+				require.FailNow(t, "Timed out waiting for message to be written")
+			}
+		}
+
 		select {
 		case entry := <-entryChan:
-			require.Equal(t, expectedRecord, entry.Record)
-		case <-time.After(time.Second):
-			require.FailNow(t, "Timed out waiting for message to be written")
+			require.FailNow(t, "Unexpected entry: %s", entry)
+		case <-time.After(100 * time.Millisecond):
+			return
 		}
-	})
+	}
+}
 
+func TestUDPInput(t *testing.T) {
+	t.Run("Simple", udpInputTest([]byte("message1"), []string{"message1"}))
+	t.Run("TrailingNewlines", udpInputTest([]byte("message1\n"), []string{"message1"}))
+	t.Run("TrailingCRNewlines", udpInputTest([]byte("message1\r\n"), []string{"message1"}))
+	t.Run("NewlineInMessage", udpInputTest([]byte("message1\nmessage2\n"), []string{"message1\nmessage2"}))
+}
+
+func BenchmarkUdpInput(b *testing.B) {
+	cfg := NewUDPInputConfig("test_id")
+	address := newRandListenAddress()
+	cfg.ListenAddress = address
+
+	newOperator, err := cfg.Build(testutil.NewBuildContext(b))
+	require.NoError(b, err)
+
+	fakeOutput := testutil.NewFakeOutput(b)
+	udpInput := newOperator.(*UDPInput)
+	udpInput.InputOperator.OutputOperators = []operator.Operator{fakeOutput}
+
+	err = udpInput.Start()
+	require.NoError(b, err)
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := net.Dial("udp", address)
+		require.NoError(b, err)
+		defer udpInput.Stop()
+		defer conn.Close()
+		message := []byte("message\n")
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_, err := conn.Write(message)
+				require.NoError(b, err)
+			}
+		}
+	}()
+
+	for i := 0; i < b.N; i++ {
+		<-fakeOutput.Received
+	}
+
+	defer close(done)
 }


### PR DESCRIPTION
## Description of Changes

Fixes a bug in the TCP input where it doesn't trim carriage returns from the message, causing downstream syslog parsing issues. Additionally, a number of small clean-ups for the TCP and UDP inputs.

Notes:
- TCP input now uses a scanner, which is reduces copies, reduces allocations, and makes the logic simpler
- UDP reuses the buffer it's reading into, reducing allocations
- Debug message noise is reduced by only erroring when we get an unexpected error (an error when we haven't told the listener to close)
- Adds a benchmark for the TCP and UDP inputs
- Adds a Makefile task `bench`
- Adds a `FakeOutput` to the testutil package, which has much less overhead than the mock output, so it can be used for benchmarking. Additionally, seems like it'll be simpler to use in most test cases that don't need special behavior. 
- The functions in `testutil` now use a TestingT interface, which is also implemented by `testing.B` so we can use testutil functions in benchmarks
- Cleaned up UDP and TCP tests so that we can do simple array-driven tests. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
