### PR TITLE
Include file name by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+### Changed
+- In the file input operator, file name and path fields are now added with `include_file_name` (default `true`) and `include_file_path` (default `false`)
+
 ## [0.9.6] - 2020-08-04
 ### Changed
 - Fork go-syslog to support long sdnames that are not rfc5424-compliant

--- a/commands/example_test.go
+++ b/commands/example_test.go
@@ -59,13 +59,13 @@ func TestTomcatExample(t *testing.T) {
 	}()
 	defer func() { <-done }()
 
-	expected := `{"timestamp":"2019-03-13T10:43:00-04:00","severity":60,"labels":{"log_type":"file_input"},"record":{"bytes_sent":"-","http_method":"GET","http_status":"404","remote_host":"10.66.2.46","remote_user":"-","url_path":"/"}}
-{"timestamp":"2019-03-13T10:43:01-04:00","severity":60,"labels":{"log_type":"file_input"},"record":{"bytes_sent":"-","http_method":"GET","http_status":"404","remote_host":"10.66.2.46","remote_user":"-","url_path":"/favicon.ico"}}
-{"timestamp":"2019-03-13T10:43:08-04:00","severity":30,"labels":{"log_type":"file_input"},"record":{"bytes_sent":"-","http_method":"GET","http_status":"302","remote_host":"10.66.2.46","remote_user":"-","url_path":"/manager"}}
-{"timestamp":"2019-03-13T10:43:08-04:00","severity":60,"labels":{"log_type":"file_input"},"record":{"bytes_sent":"3420","http_method":"GET","http_status":"403","remote_host":"10.66.2.46","remote_user":"-","url_path":"/manager/"}}
-{"timestamp":"2019-03-13T11:00:26-04:00","severity":60,"labels":{"log_type":"file_input"},"record":{"bytes_sent":"2473","http_method":"GET","http_status":"401","remote_host":"10.66.2.46","remote_user":"-","url_path":"/manager/html"}}
-{"timestamp":"2019-03-13T11:00:53-04:00","severity":20,"labels":{"log_type":"file_input"},"record":{"bytes_sent":"11936","http_method":"GET","http_status":"200","remote_host":"10.66.2.46","remote_user":"tomcat","url_path":"/manager/html"}}
-{"timestamp":"2019-03-13T11:00:53-04:00","severity":20,"labels":{"log_type":"file_input"},"record":{"bytes_sent":"19698","http_method":"GET","http_status":"200","remote_host":"10.66.2.46","remote_user":"-","url_path":"/manager/images/asf-logo.svg"}}
+	expected := `{"timestamp":"2019-03-13T10:43:00-04:00","severity":60,"labels":{"file_name":"access.log","log_type":"file_input"},"record":{"bytes_sent":"-","http_method":"GET","http_status":"404","remote_host":"10.66.2.46","remote_user":"-","url_path":"/"}}
+{"timestamp":"2019-03-13T10:43:01-04:00","severity":60,"labels":{"file_name":"access.log","log_type":"file_input"},"record":{"bytes_sent":"-","http_method":"GET","http_status":"404","remote_host":"10.66.2.46","remote_user":"-","url_path":"/favicon.ico"}}
+{"timestamp":"2019-03-13T10:43:08-04:00","severity":30,"labels":{"file_name":"access.log","log_type":"file_input"},"record":{"bytes_sent":"-","http_method":"GET","http_status":"302","remote_host":"10.66.2.46","remote_user":"-","url_path":"/manager"}}
+{"timestamp":"2019-03-13T10:43:08-04:00","severity":60,"labels":{"file_name":"access.log","log_type":"file_input"},"record":{"bytes_sent":"3420","http_method":"GET","http_status":"403","remote_host":"10.66.2.46","remote_user":"-","url_path":"/manager/"}}
+{"timestamp":"2019-03-13T11:00:26-04:00","severity":60,"labels":{"file_name":"access.log","log_type":"file_input"},"record":{"bytes_sent":"2473","http_method":"GET","http_status":"401","remote_host":"10.66.2.46","remote_user":"-","url_path":"/manager/html"}}
+{"timestamp":"2019-03-13T11:00:53-04:00","severity":20,"labels":{"file_name":"access.log","log_type":"file_input"},"record":{"bytes_sent":"11936","http_method":"GET","http_status":"200","remote_host":"10.66.2.46","remote_user":"tomcat","url_path":"/manager/html"}}
+{"timestamp":"2019-03-13T11:00:53-04:00","severity":20,"labels":{"file_name":"access.log","log_type":"file_input"},"record":{"bytes_sent":"19698","http_method":"GET","http_status":"200","remote_host":"10.66.2.46","remote_user":"-","url_path":"/manager/images/asf-logo.svg"}}
 `
 
 	timeout := time.After(5 * time.Second)

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -62,9 +62,9 @@ pipeline:
 		require.NoError(t, err)
 	}()
 
-	expectedPattern := `{"timestamp":".*","severity":0,"labels":{"log_type":"file_input"},"record":{"message":"log1"}}
-{"timestamp":".*","severity":0,"labels":{"log_type":"file_input"},"record":{"message":"log2"}}
-{"timestamp":".*","severity":0,"labels":{"log_type":"file_input"},"record":{"message":"log3"}}
+	expectedPattern := `{"timestamp":".*","severity":0,"labels":{"file_name":"input.log","log_type":"file_input"},"record":{"message":"log1"}}
+{"timestamp":".*","severity":0,"labels":{"file_name":"input.log","log_type":"file_input"},"record":{"message":"log2"}}
+{"timestamp":".*","severity":0,"labels":{"file_name":"input.log","log_type":"file_input"},"record":{"message":"log3"}}
 `
 
 	time.Sleep(1000 * time.Millisecond)

--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -4,22 +4,22 @@ The `file_input` operator reads logs from files. It will place the lines read in
 
 ### Configuration Fields
 
-| Field             | Default          | Description                                                                                                         |
-| ---               | ---              | ---                                                                                                                 |
-| `id`              | `file_input`     | A unique identifier for the operator                                                                                |
-| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                    |
-| `include`         | required         | A list of file glob patterns that match the file paths to be read                                                   |
-| `exclude`         | []               | A list of file glob patterns to exclude from reading                                                                |
-| `poll_interval`   | 200ms            | The duration between filesystem polls                                                                               |
-| `multiline`       |                  | A `multiline` configuration block. See below for details                                                            |
-| `write_to`        | $                | A [field](/docs/types/field.md) that will be set to the log message                                                 |
-| `encoding`        | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options                |
-| `file_path_field` |                  | A [field](/docs/types/field.md) that will be set to the path of the file the entry was read from                    |
-| `file_name_field` |                  | A [field](/docs/types/field.md) that will be set to the name of the file the entry was read from                    |
-| `start_at`        | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                             |
-| `max_log_size`    | 1048576          | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory. |
-| `log_type`        | `file_input`     | The log_type label appended to all discovered entries                                                               |
-| `append_log_type` | `true`           | If true, appends the log_type label to all entries                                                                  |
+| Field               | Default          | Description                                                                                                        |
+| ---                 | ---              | ---                                                                                                                |
+| `id`                | `file_input`     | A unique identifier for the operator                                                                               |
+| `output`            | Next in pipeline | The connected operator(s) that will receive all outbound entries                                                   |
+| `include`           | required         | A list of file glob patterns that match the file paths to be read                                                  |
+| `exclude`           | []               | A list of file glob patterns to exclude from reading                                                               |
+| `poll_interval`     | 200ms            | The duration between filesystem polls                                                                              |
+| `multiline`         |                  | A `multiline` configuration block. See below for details                                                           |
+| `write_to`          | $                | A [field](/docs/types/field.md) that will be set to the log message                                                |
+| `encoding`          | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
+| `include_file_name` | `true`           | Whether to add the file name as the label `file_name`                                                              |
+| `include_file_path` | `false`          | Whether to add the file path as the label `file_path`                                                              |
+| `start_at`          | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
+| `max_log_size`      | 1048576          | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
+| `log_type`          | `file_input`     | The log_type label appended to all discovered entries                                                              |
+| `append_log_type`   | `true`           | If true, appends the log_type label to all entries                                                                 |
 
 Note that by default, no logs will be read unless the monitored file is actively being written to because `start_at` defaults to `end`.
 

--- a/examples/k8s/openshift.yaml
+++ b/examples/k8s/openshift.yaml
@@ -1,0 +1,93 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: carbon-metadata
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: carbon-metadata
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+    verbs: ["get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: carbon-metadata
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: carbon-metadata
+subjects:
+  - kind: ServiceAccount
+    name: carbon-metadata
+    namespace: default
+---
+kind: ConfigMap
+metadata:
+  name: carbon-config
+  namespace: default
+apiVersion: v1
+data:
+  config.yaml: |2-
+    pipeline:
+      - type: aks
+        container_log_path: /var/log/containers/*
+        kubelet_journald_log_path: /var/log/journal
+        start_at: beginning
+      - type: drop_output
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: carbon
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      name: carbon
+  template:
+    metadata:
+      labels:
+        name: carbon
+    spec:
+      serviceAccountName: carbon-metadata
+      containers:
+        - name: carbon
+          image: observiq/carbon:dev
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "250Mi"
+              cpu: 100m
+            requests:
+              memory: "250Mi"
+              cpu: 100m
+          volumeMounts:
+            - mountPath: /carbon_home/config.yaml
+              name: config
+              subPath: config.yaml
+            - mountPath: /var/log
+              name: varlog
+            - mountPath: /var/lib/docker/containers
+              name: dockerlogs
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 5
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockerlogs
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: config
+          configMap:
+            name: carbon-config

--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 

--- a/operator/builtin/input/file/read_to_end.go
+++ b/operator/builtin/input/file/read_to_end.go
@@ -64,6 +64,7 @@ func ReadToEnd(
 	decoder := encoding.NewDecoder()
 	decodeBuffer := make([]byte, 16384)
 
+	fileName := filepath.Base(file.Name())
 	emit := func(msgBuf []byte) {
 		decoder.Reset()
 		var nDst int
@@ -81,7 +82,7 @@ func ReadToEnd(
 
 		e := inputOperator.NewEntry(string(decodeBuffer[:nDst]))
 		e.Set(filePathField, path)
-		e.Set(fileNameField, filepath.Base(file.Name()))
+		e.Set(fileNameField, fileName)
 		inputOperator.Write(ctx, e)
 	}
 


### PR DESCRIPTION
## Description of Changes

Additionally, removes the `file_name_field` and `file_path_field`
arguments from the file input operator in favor of `include_file_name`
and `include_file_path`.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
