### PR TITLE
Add parameters to BuildContext

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -21,9 +21,10 @@ type LogAgent struct {
 	Database  string
 	*zap.SugaredLogger
 
-	database operator.Database
-	pipeline *pipeline.Pipeline
-	running  bool
+	buildParams map[string]interface{}
+	database    operator.Database
+	pipeline    *pipeline.Pipeline
+	running     bool
 }
 
 // Start will start the log monitoring process.
@@ -48,6 +49,7 @@ func (a *LogAgent) Start() error {
 		PluginRegistry: registry,
 		Logger:         a.SugaredLogger,
 		Database:       a.database,
+		Parameters:     a.buildParams,
 	}
 
 	pipeline, err := a.Config.Pipeline.BuildPipeline(buildContext)
@@ -110,5 +112,11 @@ func NewLogAgent(cfg *Config, logger *zap.SugaredLogger, operatorDir, databaseFi
 		SugaredLogger: logger,
 		PluginDir:     operatorDir,
 		Database:      databaseFile,
+		buildParams:   make(map[string]interface{}),
 	}
+}
+
+func (a *LogAgent) WithBuildParameter(key string, value interface{}) *LogAgent {
+	a.buildParams[key] = value
+	return a
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -8,7 +8,25 @@ import (
 
 	"github.com/observiq/carbon/internal/testutil"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
+
+func TestNewLogAgent(t *testing.T) {
+	mockCfg := Config{}
+	mockLogger := zap.NewNop().Sugar()
+	mockPluginDir := "/some/path/plugins"
+	mockDatabaseFile := "/some/path/database"
+	mockParameterKey := "test"
+	mockParameterValue := "value"
+	agent := NewLogAgent(&mockCfg, mockLogger, mockPluginDir, mockDatabaseFile).
+		WithBuildParameter(mockParameterKey, mockParameterValue)
+
+	require.Equal(t, &mockCfg, agent.Config)
+	require.Equal(t, mockLogger, agent.SugaredLogger)
+	require.Equal(t, mockPluginDir, agent.PluginDir)
+	require.Equal(t, mockDatabaseFile, agent.Database)
+	require.Equal(t, mockParameterValue, agent.buildParams[mockParameterKey])
+}
 
 func TestOpenDatabase(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {

--- a/operator/config.go
+++ b/operator/config.go
@@ -25,6 +25,7 @@ type Builder interface {
 type BuildContext struct {
 	PluginRegistry PluginRegistry
 	Database       Database
+	Parameters     map[string]interface{}
 	Logger         *zap.SugaredLogger
 }
 


### PR DESCRIPTION
This allows users to specify extra parameters when instantiating a log agent.
This is useful for providing handles to certain operators.

## Description of Changes

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
