### PR TITLE
Add current version to the user agent string

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -12,11 +12,7 @@ func NewVersionCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Print the carbon version",
 		Run: func(_ *cobra.Command, _ []string) {
-			if version.Version != "" {
-				println(version.Version)
-			} else {
-				println(version.GitHash)
-			}
+			println(version.GetVersion())
 		},
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,3 +5,12 @@ var Version string
 
 // GitHash is the current git hash of the carbon library
 var GitHash string
+
+func GetVersion() string {
+	if Version != "" {
+		return Version
+	} else if GitHash != "" {
+		return GitHash
+	}
+	return "unknown"
+}

--- a/operator/builtin/output/google_cloud.go
+++ b/operator/builtin/output/google_cloud.go
@@ -13,6 +13,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	gax "github.com/googleapis/gax-go"
 	"github.com/observiq/carbon/entry"
+	"github.com/observiq/carbon/internal/version"
 	"github.com/observiq/carbon/operator"
 	"github.com/observiq/carbon/operator/buffer"
 	"github.com/observiq/carbon/operator/helper"
@@ -141,7 +142,7 @@ func (p *GoogleCloudOutput) Start() error {
 
 	options := make([]option.ClientOption, 0, 2)
 	options = append(options, option.WithCredentials(credentials))
-	options = append(options, option.WithUserAgent("CarbonLogAgent/0.0.9"))
+	options = append(options, option.WithUserAgent("CarbonLogAgent/"+version.GetVersion()))
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
## Description of Changes

Our version for the Google Cloud user agent was old and static. This updates it so that it will be updated with each new release.

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
