### PR TITLE
Add missing integer types to protobuf conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Google Cloud Output failure when sent a field of type uint16
+
 ## [0.9.7] - 2020-08-05
 ### Changed
 - In the file input operator, file name and path fields are now added with `include_file_name` (default `true`) and `include_file_path` (default `false`)

--- a/operator/builtin/output/google_cloud.go
+++ b/operator/builtin/output/google_cloud.go
@@ -290,15 +290,25 @@ func jsonValueToStructValue(v interface{}) *structpb.Value {
 	switch x := v.(type) {
 	case bool:
 		return &structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: x}}
+	case float32:
+		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
 	case float64:
 		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: x}}
 	case int:
 		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
-	case int64:
+	case int8:
+		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
+	case int16:
 		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
 	case int32:
 		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
+	case int64:
+		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
 	case uint:
+		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
+	case uint8:
+		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
+	case uint16:
 		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}
 	case uint32:
 		return &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(x)}}


### PR DESCRIPTION
## Description of Changes

Add the remaining integer types to the Google Cloud output protobuf conversion. 

The recent addition of EventID to the Windows Event plugin caused a regression because it used `uint16`, which was not enumerated in the switch statement. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
