### PR TITLE
Google cloud network mocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	go.etcd.io/bbolt v1.3.4
 	go.uber.org/zap v1.15.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 	golang.org/x/text v0.3.3
@@ -31,7 +31,7 @@ require (
 	gonum.org/v1/gonum v0.6.2
 	google.golang.org/api v0.20.0
 	google.golang.org/genproto v0.0.0-20200304201815-d429ff31ee6c
-	google.golang.org/grpc v1.27.1 // indirect
+	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect

--- a/operator/builtin/output/google_cloud.go
+++ b/operator/builtin/output/google_cloud.go
@@ -11,7 +11,6 @@ import (
 	vkit "cloud.google.com/go/logging/apiv2"
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
-	gax "github.com/googleapis/gax-go"
 	"github.com/observiq/carbon/entry"
 	"github.com/observiq/carbon/internal/version"
 	"github.com/observiq/carbon/operator"
@@ -93,14 +92,8 @@ type GoogleCloudOutput struct {
 	traceField   *entry.Field
 	spanIDField  *entry.Field
 
-	client  CloudLoggingClient
+	client  *vkit.Client
 	timeout time.Duration
-}
-
-// CloudLoggingClient is a client that writes entries to google cloud logging
-type CloudLoggingClient interface {
-	Close() error
-	WriteLogEntries(context.Context, *logpb.WriteLogEntriesRequest, ...gax.CallOption) (*logpb.WriteLogEntriesResponse, error)
 }
 
 // Start will start the google cloud logger.


### PR DESCRIPTION
## Description of Changes

- Change the test server to actually send network requests over GRPC. Allows our tests and benchmarks to more accurately represent real conditions, and actually runs the code in the Google client rather than mocking it.
- Add entry-parameterized benchmarks for Google Cloud Output. 

Sample benchmark output:
```
BenchmarkGoogleCloudOutput
BenchmarkGoogleCloudOutput/Simple
BenchmarkGoogleCloudOutput/Simple-8              2271727               484 ns/op             693 B/op          9 allocs/op
BenchmarkGoogleCloudOutput/MapRecord
BenchmarkGoogleCloudOutput/MapRecord-8            978750              1311 ns/op            1817 B/op         33 allocs/op
BenchmarkGoogleCloudOutput/LargeMapRecord
BenchmarkGoogleCloudOutput/LargeMapRecord-8        61021             20024 ns/op           18453 B/op        476 allocs/op
BenchmarkGoogleCloudOutput/DeepMapRecord
BenchmarkGoogleCloudOutput/DeepMapRecord-8        117739             16092 ns/op           13138 B/op        273 allocs/op
BenchmarkGoogleCloudOutput/Labels
BenchmarkGoogleCloudOutput/Labels-8              1194003              1036 ns/op            1485 B/op         27 allocs/op
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [ ] CI passes
