### PR TITLE
Add compression support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a default function to plugin templates
 - Add a host metadata operator that adds hostname to entries
+- Google Cloud Output option to enable gzip compression
 
 ## [0.9.7] - 2020-08-05
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Google Cloud Output failure when sent a field of type uint16
 ### Added
 - Added a default function to plugin templates
-- Add a host metadata operator that adds hostname to entries
+- Add a host metadata operator that adds hostname and IP to entries
 - Google Cloud Output option to enable gzip compression
 
 ## [0.9.7] - 2020-08-05

--- a/docs/operators/google_cloud_output.md
+++ b/docs/operators/google_cloud_output.md
@@ -14,6 +14,7 @@ The `google_cloud_output` operator will send entries to Google Cloud Logging.
 | `severity_field`   |                       | A [field](/docs/types/field.md) for the severity on the log entry                                          |
 | `trace_field`      |                       | A [field](/docs/types/field.md) for the trace on the log entry                                             |
 | `span_id_field`    |                       | A [field](/docs/types/field.md) for the span_id on the log entry                                           |
+| `use_compression`  | `false`               | Whether to compress the log entry payloads with gzip before sending to Google Cloud                        |
 | `timeout`          | 10s                   | A [duration](/docs/types/duration.md) indicating how long to wait for the API to respond before timing out |
 
 If both `credentials` and `credentials_file` are left empty, the agent will attempt to find

--- a/operator/buffer/buffer.go
+++ b/operator/buffer/buffer.go
@@ -27,7 +27,7 @@ func NewConfig() Config {
 		BundleByteThreshold:  4 * 1024 * 1024 * 1024,   // 4MB
 		BundleByteLimit:      4 * 1024 * 1024 * 1024,   // 4MB
 		BufferedByteLimit:    500 * 1024 * 1024 * 1024, // 500MB
-		HandlerLimit:         32,
+		HandlerLimit:         16,
 		Retry:                NewRetryConfig(),
 	}
 }


### PR DESCRIPTION
## Description of Changes

Adds compression support to the Google Cloud Output. 

Also increases the timeout for write calls and reduces the handler limit to reduce contention for network resources. 

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
