### PR TITLE
Add missing source.Stop()

### DIFF
--- a/operator/builtin/input/file/file_test.go
+++ b/operator/builtin/input/file/file_test.go
@@ -821,6 +821,7 @@ func TestEncodings(t *testing.T) {
 
 			err = source.Start()
 			require.NoError(t, err)
+			defer source.Stop()
 
 			for _, expected := range tc.expected {
 				select {
@@ -875,12 +876,12 @@ func BenchmarkFileInput(b *testing.B) {
 			err = fileOperator.Start()
 			require.NoError(b, err)
 
-      file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
-      require.NoError(b, err)
+			file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
+			require.NoError(b, err)
 
-      for i := 0; i < b.N; i++ {
-        file.WriteString("testlog\n")
-      }
+			for i := 0; i < b.N; i++ {
+				file.WriteString("testlog\n")
+			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/operator/builtin/parser/syslog.go
+++ b/operator/builtin/parser/syslog.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	syslog "github.com/observiq/go-syslog/v3"
-	"github.com/observiq/go-syslog/v3/rfc3164"
-	"github.com/observiq/go-syslog/v3/rfc5424"
 	"github.com/observiq/carbon/entry"
 	"github.com/observiq/carbon/operator"
 	"github.com/observiq/carbon/operator/helper"
+	syslog "github.com/observiq/go-syslog/v3"
+	"github.com/observiq/go-syslog/v3/rfc3164"
+	"github.com/observiq/go-syslog/v3/rfc5424"
 )
 
 func init() {


### PR DESCRIPTION
## Description of Changes

- Add a missing `source.Stop()` so tests exit cleanly
- Fix spacing that somehow got out of sync

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
