### PR TITLE
Compress by default

### DIFF
--- a/docs/operators/google_cloud_output.md
+++ b/docs/operators/google_cloud_output.md
@@ -14,7 +14,7 @@ The `google_cloud_output` operator will send entries to Google Cloud Logging.
 | `severity_field`   |                       | A [field](/docs/types/field.md) for the severity on the log entry                                          |
 | `trace_field`      |                       | A [field](/docs/types/field.md) for the trace on the log entry                                             |
 | `span_id_field`    |                       | A [field](/docs/types/field.md) for the span_id on the log entry                                           |
-| `use_compression`  | `false`               | Whether to compress the log entry payloads with gzip before sending to Google Cloud                        |
+| `use_compression`  | `true`                | Whether to compress the log entry payloads with gzip before sending to Google Cloud                        |
 | `timeout`          | 10s                   | A [duration](/docs/types/duration.md) indicating how long to wait for the API to respond before timing out |
 
 If both `credentials` and `credentials_file` are left empty, the agent will attempt to find

--- a/operator/builtin/output/google_cloud.go
+++ b/operator/builtin/output/google_cloud.go
@@ -35,7 +35,7 @@ func NewGoogleCloudOutputConfig(operatorID string) *GoogleCloudOutputConfig {
 		OutputConfig:   helper.NewOutputConfig(operatorID, "google_cloud_output"),
 		BufferConfig:   buffer.NewConfig(),
 		Timeout:        operator.Duration{Duration: 30 * time.Second},
-		UseCompression: false,
+		UseCompression: true,
 	}
 }
 

--- a/operator/builtin/output/google_cloud_test.go
+++ b/operator/builtin/output/google_cloud_test.go
@@ -387,13 +387,13 @@ func BenchmarkGoogleCloudOutput(b *testing.B) {
 			nil,
 		},
 		{
-			"Compression",
+			"NoCompression",
 			&entry.Entry{
 				Timestamp: t,
-				Record:    "compressiblecompressiblecompressiblecompressiblecompressiblecompressiblecompressible",
+				Record:    "test",
 			},
 			func(cfg *GoogleCloudOutputConfig) {
-				cfg.UseCompression = true
+				cfg.UseCompression = false
 			},
 		},
 	}


### PR DESCRIPTION
## Description of Changes

I took another look at compression, and realized my initial evaluation of the overhead of compression was based off the wrong benchmark. Looking at the benchmarks below, it appears enabling compression adds a negligible (maybe even negative) overhead. Considering that, it seems to make sense to enable compression by default, which is what this PR does. It also modifies the compression benchmark to be directly comparable to the simple benchmark. 

```
name                               time/op
GoogleCloudOutput/Simple-8         416ns ± 2%
GoogleCloudOutput/NoCompression-8  437ns ±14%
```

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
