### PR TITLE
Entry resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- The `Resource` field was added to Entry
+- The `Identifier` helper was created to assist with writing to `Resource`
+
+### Removed
+- The `Tags` field was removed from Entry
+
+### Changed
+- The `host_metadata` operator now writes to an entry's `Resource` field, instead of Labels
+- The `host_labeler` helper has been renamed `host_identifier`
+- The `metadata` operator embeds the `Identifier` helper and supports writing to `Resource`
+- Input operators embed the `Identifier` helper and support writing to `Resource`
+- The `k8s_event` operator now supports the `write_to`, `labels`, and `resource` configuration options
+
 ## [0.9.9] - 2020-08-14
 ### Added
 - Kubernetes events input operator ([PR88](https://github.com/observIQ/carbon/pull/88))

--- a/docs/operators/file_input.md
+++ b/docs/operators/file_input.md
@@ -12,13 +12,14 @@ The `file_input` operator reads logs from files. It will place the lines read in
 | `exclude`           | []               | A list of file glob patterns to exclude from reading                                                               |
 | `poll_interval`     | 200ms            | The duration between filesystem polls                                                                              |
 | `multiline`         |                  | A `multiline` configuration block. See below for details                                                           |
-| `write_to`          | $                | A [field](/docs/types/field.md) that will be set to the log message                                                |
+| `write_to`          | $                | The record [field](/docs/types/field.md) written to when creating a new log entry                                  |
 | `encoding`          | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `include_file_name` | `true`           | Whether to add the file name as the label `file_name`                                                              |
 | `include_file_path` | `false`          | Whether to add the file path as the label `file_path`                                                              |
 | `start_at`          | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
 | `max_log_size`      | 1048576          | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
-| `labels`            | {}               | A map of `key: value` labels to add to the entry                                                                   |
+| `labels`            | {}               | A map of `key: value` labels to add to the entry's labels                                                          |
+| `resource`          | {}               | A map of `key: value` labels to add to the entry's resource                                                        |
 
 Note that by default, no logs will be read unless the monitored file is actively being written to because `start_at` defaults to `end`.
 

--- a/docs/operators/host_metadata.md
+++ b/docs/operators/host_metadata.md
@@ -1,14 +1,15 @@
 ## `host_metadata` operator
 
-The `host_metadata` operator adds labels to incoming entries.
+The `host_metadata` operator adds hostname and ip to the resource of incoming entries.
 
 ### Configuration Fields
 
 | Field              | Default          | Description                                                                                     |
 | ---                | ---              | ---                                                                                             |
-| `id`               | `metadata`       | A unique identifier for the operator                                                            |
+| `id`               | `host_metadata`  | A unique identifier for the operator                                                            |
 | `output`           | Next in pipeline | The connected operator(s) that will receive all outbound entries                                |
-| `include_hostname` | `true`           | Whether to set the `hostname` label on entries                                                  |
+| `include_hostname` | `true`           | Whether to set the `hostname` on the resource of incoming entries                               |
+| `include_ip`       | `true`           | Whether to set the `ip` on the resource of incoming entries                                     |
 | `on_error`         | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md) |
 
 ### Example Configurations
@@ -19,6 +20,7 @@ Configuration:
 ```yaml
 - type: host_metadata
   include_hostname: true
+  include_ip: true
 ```
 
 <table>
@@ -29,7 +31,6 @@ Configuration:
 ```json
 {
   "timestamp": "2020-06-15T11:15:50.475364-04:00",
-  "labels": {},
   "record": {
     "message": "test"
   }
@@ -42,8 +43,9 @@ Configuration:
 ```json
 {
   "timestamp": "2020-06-15T11:15:50.475364-04:00",
-  "labels": {
-    "hostname": "my_host"
+  "resource": {
+    "hostname": "my_host",
+    "ip": "0.0.0.0",
   },
   "record": {
     "message": "test"

--- a/docs/operators/journald_input.md
+++ b/docs/operators/journald_input.md
@@ -14,10 +14,10 @@ The `journald_input` operator will use the `__REALTIME_TIMESTAMP` field of the j
 | `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                                 |
 | `directory`       |                  | A directory containing journal files to read entries from                                        |
 | `files`           |                  | A list of journal files to read entries from                                                     |
-| `write_to`        | $                | A [field](/docs/types/field.md) that will be set to the path of the file the entry was read from |
+| `write_to`        | $                | The record [field](/docs/types/field.md) written to when creating a new log entry                |
 | `start_at`        | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`          |
-| `labels`          | {}               | A map of `key: value` labels to add to the entry                                                 |
-
+| `labels`          | {}               | A map of `key: value` labels to add to the entry's labels                                        |
+| `resource`        | {}               | A map of `key: value` labels to add to the entry's resource                                      |
 
 ### Example Configurations
 

--- a/docs/operators/k8s_event_input.md
+++ b/docs/operators/k8s_event_input.md
@@ -5,12 +5,15 @@ Kubernetes API, and currently requires that Carbon is running inside a Kubernete
 
 ### Configuration Fields
 
-| Field        | Default           | Description                                                                          |
-| ---          | ---               | ---                                                                                  |
-| `id`         | `k8s_event_input` | A unique identifier for the operator                                                 |
-| `output`     | Next in pipeline  | The connected operator(s) that will receive all outbound entries                     |
-| `namespaces` | All namespaces    | An array of namespaces to collect events from. If unset, defaults to all namespaces. |
-
+| Field        | Default           | Description                                                                                      |
+| ---          | ---               | ---                                                                                              |
+| `id`         | `k8s_event_input` | A unique identifier for the operator                                                             |
+| `output`     | Next in pipeline  | The connected operator(s) that will receive all outbound entries                                 |
+| `namespaces` | All namespaces    | An array of namespaces to collect events from. If unset, defaults to all namespaces.             |
+| `write_to`   | $                 | The record [field](/docs/types/field.md) written to when creating a new log entry                |
+| `labels`     | {}                | A map of `key: value` labels to add to the entry's labels                                        |
+| `resource`   | {}                | A map of `key: value` labels to add to the entry's resource                                      |
+ 
 ### Example Configurations
 
 #### Mock a file input

--- a/docs/operators/metadata.md
+++ b/docs/operators/metadata.md
@@ -8,7 +8,8 @@ The `metadata` operator adds labels to incoming entries.
 | ---        | ---              | ---                                                                                             |
 | `id`       | `metadata`       | A unique identifier for the operator                                                            |
 | `output`   | Next in pipeline | The connected operator(s) that will receive all outbound entries                                |
-| `labels`   | {}               | A map of `key: value` labels to add to the entry                                                |
+| `labels`   | {}               | A map of `key: value` labels to add to the entry's labels                                       |
+| `resource` | {}               | A map of `key: value` labels to add to the entry's resource                                     |
 | `on_error` | `send`           | The behavior of the operator if it encounters an error. See [on_error](/docs/types/on_error.md) |
 
 Inside the label values, an [expression](/docs/types/expression.md) surrounded by `EXPR()`
@@ -18,13 +19,15 @@ with the `$` variable in the expression so labels can be added dynamically from 
 ### Example Configurations
 
 
-#### Add static tags and labels
+#### Add static labels and resource
 
 Configuration:
 ```yaml
 - type: metadata
   labels:
     environment: "production"
+  resource:
+    cluster: "blue"
 ```
 
 <table>
@@ -50,6 +53,9 @@ Configuration:
   "timestamp": "2020-06-15T11:15:50.475364-04:00",
   "labels": {
     "environment": "production"
+  },
+  "resource": {
+    "cluster": "blue"
   },
   "record": {
     "message": "test"

--- a/docs/operators/tcp_input.md
+++ b/docs/operators/tcp_input.md
@@ -4,13 +4,14 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 
 ### Configuration Fields
 
-| Field             | Default          | Description                                                         |
-| ---               | ---              | ---                                                                 |
-| `id`              | `tcp_input`      | A unique identifier for the operator                                |
-| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries    |
-| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                          |
-| `write_to`        | $                | A [field](/docs/types/field.md) that will be set to the log message |
-| `labels`          | {}               | A map of `key: value` labels to add to the entry                    |
+| Field             | Default          | Description                                                                       |
+| ---               | ---              | ---                                                                               |
+| `id`              | `tcp_input`      | A unique identifier for the operator                                              |
+| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                  |
+| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                        |
+| `write_to`        | $                | The record [field](/docs/types/field.md) written to when creating a new log entry |
+| `labels`          | {}               | A map of `key: value` labels to add to the entry's labels                         |
+| `resource`        | {}               | A map of `key: value` labels to add to the entry's resource                       |
 
 ### Example Configurations
 

--- a/docs/operators/udp_input.md
+++ b/docs/operators/udp_input.md
@@ -4,13 +4,14 @@ The `udp_input` operator listens for logs from UDP packets.
 
 ### Configuration Fields
 
-| Field             | Default          | Description                                                         |
-| ---               | ---              | ---                                                                 |
-| `id`              | `udp_input`      | A unique identifier for the operator                                |
-| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries    |
-| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                          |
-| `write_to`        | $                | A [field](/docs/types/field.md) that will be set to the log message |
-| `labels`          | {}               | A map of `key: value` labels to add to the entry                    |
+| Field             | Default          | Description                                                                       |
+| ---               | ---              | ---                                                                               |
+| `id`              | `udp_input`      | A unique identifier for the operator                                              |
+| `output`          | Next in pipeline | The connected operator(s) that will receive all outbound entries                  |
+| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                        |
+| `write_to`        | $                | The record [field](/docs/types/field.md) written to when creating a new log entry |
+| `labels`          | {}               | A map of `key: value` labels to add to the entry's labels                         |
+| `resource`        | {}               | A map of `key: value` labels to add to the entry's resource                       |
 
 ### Example Configurations
 

--- a/docs/operators/windows_eventlog_input.md
+++ b/docs/operators/windows_eventlog_input.md
@@ -12,7 +12,9 @@ The `windows_eventlog_input` operator reads logs from the windows event log API.
 | `max_reads`       | 100                      | The maximum number of records read into memory, before beginning a new batch                 |
 | `start_at`        | `end`                    | On first startup, where to start reading logs from the API. Options are `beginning` or `end` |
 | `poll_interval`   | 1s                       | The interval at which the channel is checked for new log entries. This check begins again after all new records have been read |
-| `labels`          | {}                       | A map of `key: value` labels to add to the entry                                             |
+| `write_to`        | $                        | The record [field](/docs/types/field.md) written to when creating a new log entry            |
+| `labels`          | {}                       | A map of `key: value` labels to add to the entry's labels                                    |
+| `resource`        | {}                       | A map of `key: value` labels to add to the entry's resource                                  |
 
 ### Example Configurations
 

--- a/docs/types/entry.md
+++ b/docs/types/entry.md
@@ -8,5 +8,5 @@ Entry is the base representation of log data as it moves through a pipeline. All
 | `timestamp` | The timestamp associated with the log (RFC 3339).                                                                           |
 | `severity`  | The [severity](/docs/types/field.md) of the log.                                                                            |
 | `labels`    | A map of key/value pairs that describes the metadata of the log. This value is often used by a consumer to categorize logs. |
-| `tags`      | An array of values that describes the metadata of the log. This value is often used by a consumer to tag incoming logs.     |
+| `resource`  | A map of key/value pairs that describes the origin of the log.                                                              |
 | `record`    | The contents of the log. This value is often modified and restructured in the pipeline.                                     |

--- a/docs/types/expression.md
+++ b/docs/types/expression.md
@@ -9,7 +9,7 @@ For reference documentation of the expression language, see [here](https://githu
 Available to the expressions are a few special variables:
 - `$record` contains the entry's record
 - `$labels` contains the entry's labels
-- `$tags` contains the entry's tags
+- `$resource` contains the entry's resource
 - `$timestamp` contains the entry's timestamp
 - `env()` is a function that allows you to read environment variables
 

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -9,8 +9,8 @@ import (
 type Entry struct {
 	Timestamp time.Time         `json:"timestamp"        yaml:"timestamp"`
 	Severity  Severity          `json:"severity"         yaml:"severity"`
-	Tags      []string          `json:"tags,omitempty"   yaml:"tags,omitempty"`
 	Labels    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Resource  map[string]string `json:"resource,omitempty" yaml:"resource,omitempty"`
 	Record    interface{}       `json:"record"           yaml:"record"`
 }
 
@@ -27,6 +27,14 @@ func (entry *Entry) AddLabel(key, value string) {
 		entry.Labels = make(map[string]string)
 	}
 	entry.Labels[key] = value
+}
+
+// AddResourceKey wil add a key/value pair to the entry's resource.
+func (entry *Entry) AddResourceKey(key, value string) {
+	if entry.Resource == nil {
+		entry.Resource = make(map[string]string)
+	}
+	entry.Resource[key] = value
 }
 
 // Get will return the value of a field on the entry, including a boolean indicating if the field exists.
@@ -148,8 +156,8 @@ func (entry *Entry) Copy() *Entry {
 	return &Entry{
 		Timestamp: entry.Timestamp,
 		Severity:  entry.Severity,
-		Tags:      copyStringArray(entry.Tags),
 		Labels:    copyStringMap(entry.Labels),
+		Resource:  copyStringMap(entry.Resource),
 		Record:    copyValue(entry.Record),
 	}
 }

--- a/entry/entry_test.go
+++ b/entry/entry_test.go
@@ -124,19 +124,19 @@ func TestCopy(t *testing.T) {
 	entry.Timestamp = time.Time{}
 	entry.Record = "test"
 	entry.Labels = map[string]string{"label": "value"}
-	entry.Tags = []string{"tag"}
+	entry.Resource = map[string]string{"resource": "value"}
 	copy := entry.Copy()
 
 	entry.Severity = Severity(1)
 	entry.Timestamp = time.Now()
 	entry.Record = "new"
 	entry.Labels = map[string]string{"label": "new value"}
-	entry.Tags = []string{"new tag"}
+	entry.Resource = map[string]string{"resource": "new value"}
 
 	require.Equal(t, time.Time{}, copy.Timestamp)
 	require.Equal(t, Severity(0), copy.Severity)
-	require.Equal(t, []string{"tag"}, copy.Tags)
 	require.Equal(t, map[string]string{"label": "value"}, copy.Labels)
+	require.Equal(t, map[string]string{"resource": "value"}, copy.Resource)
 	require.Equal(t, "test", copy.Record)
 }
 

--- a/operator/builtin/input/generate_test.go
+++ b/operator/builtin/input/generate_test.go
@@ -81,8 +81,9 @@ pipeline:
 			{
 				Builder: &GenerateInputConfig{
 					InputConfig: helper.InputConfig{
-						LabelerConfig: helper.NewLabelerConfig(),
-						WriteTo:       entry.NewRecordField(),
+						LabelerConfig:    helper.NewLabelerConfig(),
+						IdentifierConfig: helper.NewIdentifierConfig(),
+						WriteTo:          entry.NewRecordField(),
 						WriterConfig: helper.WriterConfig{
 							BasicConfig: helper.BasicConfig{
 								OperatorID:   "my_generator",

--- a/operator/builtin/transformer/host_metadata.go
+++ b/operator/builtin/transformer/host_metadata.go
@@ -16,15 +16,15 @@ func init() {
 // NewHostMetadataConfig returns a HostMetadataConfig with default values
 func NewHostMetadataConfig(operatorID string) *HostMetadataConfig {
 	return &HostMetadataConfig{
-		TransformerConfig: helper.NewTransformerConfig(operatorID, "host_decorator"),
-		HostLabelerConfig: helper.NewHostLabelerConfig(),
+		TransformerConfig:    helper.NewTransformerConfig(operatorID, "host_decorator"),
+		HostIdentifierConfig: helper.NewHostIdentifierConfig(),
 	}
 }
 
 // HostMetadataConfig is the configuration of a host metadata operator
 type HostMetadataConfig struct {
-	helper.TransformerConfig `yaml:",inline"`
-	helper.HostLabelerConfig `yaml:",inline"`
+	helper.TransformerConfig    `yaml:",inline"`
+	helper.HostIdentifierConfig `yaml:",inline"`
 }
 
 // Build will build an operator from the supplied configuration
@@ -34,14 +34,14 @@ func (c HostMetadataConfig) Build(context operator.BuildContext) (operator.Opera
 		return nil, errors.Wrap(err, "failed to build transformer")
 	}
 
-	hostLabeler, err := c.HostLabelerConfig.Build()
+	hostIdentifier, err := c.HostIdentifierConfig.Build()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build host labeler")
 	}
 
 	operator := &HostMetadata{
 		TransformerOperator: transformerOperator,
-		HostLabeler:         hostLabeler,
+		HostIdentifier:      hostIdentifier,
 	}
 
 	return operator, nil
@@ -50,7 +50,7 @@ func (c HostMetadataConfig) Build(context operator.BuildContext) (operator.Opera
 // HostMetadata is an operator that can add host metadata to incoming entries
 type HostMetadata struct {
 	helper.TransformerOperator
-	helper.HostLabeler
+	helper.HostIdentifier
 }
 
 // Process will process an incoming entry using the metadata transform.
@@ -60,6 +60,6 @@ func (h *HostMetadata) Process(ctx context.Context, entry *entry.Entry) error {
 
 // Transform will transform an entry, adding the configured host metadata.
 func (h *HostMetadata) Transform(entry *entry.Entry) (*entry.Entry, error) {
-	h.HostLabeler.Label(entry)
+	h.HostIdentifier.Identify(entry)
 	return entry, nil
 }

--- a/operator/builtin/transformer/metadata_test.go
+++ b/operator/builtin/transformer/metadata_test.go
@@ -84,6 +84,60 @@ func TestMetadata(t *testing.T) {
 				return e
 			}(),
 		},
+		{
+			"AddResourceLiteral",
+			func() *MetadataOperatorConfig {
+				cfg := baseConfig()
+				cfg.Resource = map[string]helper.ExprStringConfig{
+					"key1": "value1",
+				}
+				return cfg
+			}(),
+			entry.New(),
+			func() *entry.Entry {
+				e := entry.New()
+				e.Resource = map[string]string{
+					"key1": "value1",
+				}
+				return e
+			}(),
+		},
+		{
+			"AddResourceExpr",
+			func() *MetadataOperatorConfig {
+				cfg := baseConfig()
+				cfg.Resource = map[string]helper.ExprStringConfig{
+					"key1": `EXPR("start" + "end")`,
+				}
+				return cfg
+			}(),
+			entry.New(),
+			func() *entry.Entry {
+				e := entry.New()
+				e.Resource = map[string]string{
+					"key1": "startend",
+				}
+				return e
+			}(),
+		},
+		{
+			"AddResourceEnv",
+			func() *MetadataOperatorConfig {
+				cfg := baseConfig()
+				cfg.Resource = map[string]helper.ExprStringConfig{
+					"key1": `EXPR(env("TEST_METADATA_PLUGIN_ENV"))`,
+				}
+				return cfg
+			}(),
+			entry.New(),
+			func() *entry.Entry {
+				e := entry.New()
+				e.Resource = map[string]string{
+					"key1": "foo",
+				}
+				return e
+			}(),
+		},
 	}
 
 	for _, tc := range cases {
@@ -106,6 +160,7 @@ func TestMetadata(t *testing.T) {
 			select {
 			case e := <-entryChan:
 				require.Equal(t, e.Labels, tc.expected.Labels)
+				require.Equal(t, e.Resource, tc.expected.Resource)
 			case <-time.After(time.Second):
 				require.FailNow(t, "Timed out waiting for entry to be processed")
 			}

--- a/operator/helper/expr_string.go
+++ b/operator/helper/expr_string.go
@@ -125,8 +125,8 @@ func GetExprEnv(e *entry.Entry) map[string]interface{} {
 	env["$"] = e.Record
 	env["$record"] = e.Record
 	env["$labels"] = e.Labels
+	env["$resource"] = e.Resource
 	env["$timestamp"] = e.Timestamp
-	env["$tags"] = e.Tags
 
 	return env
 }

--- a/operator/helper/expr_string_test.go
+++ b/operator/helper/expr_string_test.go
@@ -18,6 +18,9 @@ func TestExprString(t *testing.T) {
 		e.Record = map[string]interface{}{
 			"test": "value",
 		}
+		e.Resource = map[string]string{
+			"id": "value",
+		}
 		return e
 	}
 
@@ -76,6 +79,10 @@ func TestExprString(t *testing.T) {
 		{
 			"my EXPR(env('TEST_EXPR_STRING_ENV'))",
 			"my foo",
+		},
+		{
+			"EXPR( $resource.id )",
+			"value",
 		},
 	}
 

--- a/operator/helper/host_identifier.go
+++ b/operator/helper/host_identifier.go
@@ -9,9 +9,9 @@ import (
 	"github.com/observiq/carbon/errors"
 )
 
-// NewHostLabelerConfig returns a HostLabelerConfig with default values
-func NewHostLabelerConfig() HostLabelerConfig {
-	return HostLabelerConfig{
+// NewHostIdentifierConfig returns a HostIdentifierConfig with default values
+func NewHostIdentifierConfig() HostIdentifierConfig {
+	return HostIdentifierConfig{
 		IncludeHostname: true,
 		IncludeIP:       true,
 		getHostname:     getHostname,
@@ -19,8 +19,8 @@ func NewHostLabelerConfig() HostLabelerConfig {
 	}
 }
 
-// HostLabelerConfig is the configuration of a host labeler
-type HostLabelerConfig struct {
+// HostIdentifierConfig is the configuration of a host identifier
+type HostIdentifierConfig struct {
 	IncludeHostname bool `json:"include_hostname,omitempty"     yaml:"include_hostname,omitempty"`
 	IncludeIP       bool `json:"include_ip,omitempty"     yaml:"include_ip,omitempty"`
 	getHostname     func() (string, error)
@@ -28,37 +28,37 @@ type HostLabelerConfig struct {
 }
 
 // Build will build a host labeler from the supplied configuration
-func (c HostLabelerConfig) Build() (HostLabeler, error) {
-	labeler := HostLabeler{
+func (c HostIdentifierConfig) Build() (HostIdentifier, error) {
+	identifier := HostIdentifier{
 		includeHostname: c.IncludeHostname,
 		includeIP:       c.IncludeIP,
 	}
 
 	if c.getHostname == nil {
-		return labeler, fmt.Errorf("getHostname func is not set")
+		return identifier, fmt.Errorf("getHostname func is not set")
 	}
 
 	if c.getIP == nil {
-		return labeler, fmt.Errorf("getIP func is not set")
+		return identifier, fmt.Errorf("getIP func is not set")
 	}
 
 	if c.IncludeHostname {
 		hostname, err := c.getHostname()
 		if err != nil {
-			return labeler, errors.Wrap(err, "get hostname")
+			return identifier, errors.Wrap(err, "get hostname")
 		}
-		labeler.hostname = hostname
+		identifier.hostname = hostname
 	}
 
 	if c.IncludeIP {
 		ip, err := c.getIP()
 		if err != nil {
-			return labeler, errors.Wrap(err, "get ip address")
+			return identifier, errors.Wrap(err, "get ip address")
 		}
-		labeler.ip = ip
+		identifier.ip = ip
 	}
 
-	return labeler, nil
+	return identifier, nil
 }
 
 // getHostname will return the hostname of the current host
@@ -105,21 +105,21 @@ func getIP() (string, error) {
 	return ip, nil
 }
 
-// HostLabeler is a helper that adds host related metadata to an entry's labels
-type HostLabeler struct {
+// HostIdentifier is a helper that adds host related metadata to an entry's resource
+type HostIdentifier struct {
 	hostname        string
 	ip              string
 	includeHostname bool
 	includeIP       bool
 }
 
-// Label will label an entry with host related metadata
-func (h *HostLabeler) Label(entry *entry.Entry) {
+// Identify will add host related metadata to an entry's resource
+func (h *HostIdentifier) Identify(entry *entry.Entry) {
 	if h.includeHostname {
-		entry.AddLabel("hostname", h.hostname)
+		entry.AddResourceKey("hostname", h.hostname)
 	}
 
 	if h.includeIP {
-		entry.AddLabel("ip", h.ip)
+		entry.AddResourceKey("ip", h.ip)
 	}
 }

--- a/operator/helper/host_identifier_test.go
+++ b/operator/helper/host_identifier_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func MockHostLabelerConfig(includeIP, includeHostname bool, ip, hostname string) HostLabelerConfig {
-	return HostLabelerConfig{
+func MockHostIdentifierConfig(includeIP, includeHostname bool, ip, hostname string) HostIdentifierConfig {
+	return HostIdentifierConfig{
 		IncludeIP:       includeIP,
 		IncludeHostname: includeHostname,
 		getIP:           func() (string, error) { return ip, nil },
@@ -18,13 +18,13 @@ func MockHostLabelerConfig(includeIP, includeHostname bool, ip, hostname string)
 
 func TestHostLabeler(t *testing.T) {
 	cases := []struct {
-		name           string
-		config         HostLabelerConfig
-		expectedLabels map[string]string
+		name             string
+		config           HostIdentifierConfig
+		expectedResource map[string]string
 	}{
 		{
 			"HostnameAndIP",
-			MockHostLabelerConfig(true, true, "ip", "hostname"),
+			MockHostIdentifierConfig(true, true, "ip", "hostname"),
 			map[string]string{
 				"hostname": "hostname",
 				"ip":       "ip",
@@ -32,33 +32,33 @@ func TestHostLabeler(t *testing.T) {
 		},
 		{
 			"HostnameNoIP",
-			MockHostLabelerConfig(false, true, "ip", "hostname"),
+			MockHostIdentifierConfig(false, true, "ip", "hostname"),
 			map[string]string{
 				"hostname": "hostname",
 			},
 		},
 		{
 			"IPNoHostname",
-			MockHostLabelerConfig(true, false, "ip", "hostname"),
+			MockHostIdentifierConfig(true, false, "ip", "hostname"),
 			map[string]string{
 				"ip": "ip",
 			},
 		},
 		{
 			"NoHostnameNoIP",
-			MockHostLabelerConfig(false, false, "", "test"),
+			MockHostIdentifierConfig(false, false, "", "test"),
 			nil,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			labeler, err := tc.config.Build()
+			identifier, err := tc.config.Build()
 			require.NoError(t, err)
 
 			e := entry.New()
-			labeler.Label(e)
-			require.Equal(t, tc.expectedLabels, e.Labels)
+			identifier.Identify(e)
+			require.Equal(t, tc.expectedResource, e.Resource)
 		})
 	}
 }

--- a/operator/helper/identifier.go
+++ b/operator/helper/identifier.go
@@ -1,0 +1,60 @@
+package helper
+
+import (
+	"github.com/observiq/carbon/entry"
+)
+
+// NewIdentifierConfig creates a new identifier config with default values
+func NewIdentifierConfig() IdentifierConfig {
+	return IdentifierConfig{
+		Resource: make(map[string]ExprStringConfig),
+	}
+}
+
+// IdentifierConfig is the configuration of a resource identifier
+type IdentifierConfig struct {
+	Resource map[string]ExprStringConfig `json:"resource" yaml:"resource"`
+}
+
+// Build will build an identifier from the supplied configuration
+func (c IdentifierConfig) Build() (Identifier, error) {
+	identifier := Identifier{
+		resource: make(map[string]*ExprString),
+	}
+
+	for k, v := range c.Resource {
+		exprString, err := v.Build()
+		if err != nil {
+			return identifier, err
+		}
+
+		identifier.resource[k] = exprString
+	}
+
+	return identifier, nil
+}
+
+// Identifier is a helper that adds values to the resource of an entry
+type Identifier struct {
+	resource map[string]*ExprString
+}
+
+// Identify will add values to the resource of an entry
+func (i *Identifier) Identify(e *entry.Entry) error {
+	if len(i.resource) == 0 {
+		return nil
+	}
+
+	env := GetExprEnv(e)
+	defer PutExprEnv(env)
+
+	for k, v := range i.resource {
+		rendered, err := v.Render(env)
+		if err != nil {
+			return err
+		}
+		e.AddResourceKey(k, rendered)
+	}
+
+	return nil
+}

--- a/operator/helper/identifier_test.go
+++ b/operator/helper/identifier_test.go
@@ -1,0 +1,87 @@
+package helper
+
+import (
+	"os"
+	"testing"
+
+	"github.com/observiq/carbon/entry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentifier(t *testing.T) {
+	os.Setenv("TEST_METADATA_PLUGIN_ENV", "foo")
+	defer os.Unsetenv("TEST_METADATA_PLUGIN_ENV")
+
+	cases := []struct {
+		name     string
+		config   IdentifierConfig
+		input    *entry.Entry
+		expected *entry.Entry
+	}{
+		{
+			"AddLabelLiteral",
+			func() IdentifierConfig {
+				cfg := NewIdentifierConfig()
+				cfg.Resource = map[string]ExprStringConfig{
+					"key1": "value1",
+				}
+				return cfg
+			}(),
+			entry.New(),
+			func() *entry.Entry {
+				e := entry.New()
+				e.Resource = map[string]string{
+					"key1": "value1",
+				}
+				return e
+			}(),
+		},
+		{
+			"AddLabelExpr",
+			func() IdentifierConfig {
+				cfg := NewIdentifierConfig()
+				cfg.Resource = map[string]ExprStringConfig{
+					"key1": `EXPR("start" + "end")`,
+				}
+				return cfg
+			}(),
+			entry.New(),
+			func() *entry.Entry {
+				e := entry.New()
+				e.Resource = map[string]string{
+					"key1": "startend",
+				}
+				return e
+			}(),
+		},
+		{
+			"AddLabelEnv",
+			func() IdentifierConfig {
+				cfg := NewIdentifierConfig()
+				cfg.Resource = map[string]ExprStringConfig{
+					"key1": `EXPR(env("TEST_METADATA_PLUGIN_ENV"))`,
+				}
+				return cfg
+			}(),
+			entry.New(),
+			func() *entry.Entry {
+				e := entry.New()
+				e.Resource = map[string]string{
+					"key1": "foo",
+				}
+				return e
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			identifier, err := tc.config.Build()
+			require.NoError(t, err)
+
+			err = identifier.Identify(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected.Resource, tc.input.Resource)
+		})
+	}
+}

--- a/operator/helper/input_test.go
+++ b/operator/helper/input_test.go
@@ -104,13 +104,22 @@ func TestInputOperatorProcess(t *testing.T) {
 func TestInputOperatorNewEntry(t *testing.T) {
 	buildContext := testutil.NewBuildContext(t)
 	writeTo := entry.NewRecordField("test-field")
+
 	labelExpr, err := ExprStringConfig("test").Build()
+	require.NoError(t, err)
+
+	resourceExpr, err := ExprStringConfig("resource").Build()
 	require.NoError(t, err)
 
 	input := InputOperator{
 		Labeler: Labeler{
 			labels: map[string]*ExprString{
 				"test-label": labelExpr,
+			},
+		},
+		Identifier: Identifier{
+			resource: map[string]*ExprString{
+				"resource-key": resourceExpr,
 			},
 		},
 		WriterOperator: WriterOperator{
@@ -130,7 +139,11 @@ func TestInputOperatorNewEntry(t *testing.T) {
 	require.True(t, exists)
 	require.Equal(t, "test", value)
 
-	label, exists := entry.Labels["test-label"]
+	labelValue, exists := entry.Labels["test-label"]
 	require.True(t, exists)
-	require.Equal(t, "test", label)
+	require.Equal(t, "test", labelValue)
+
+	resourceValue, exists := entry.Resource["resource-key"]
+	require.True(t, exists)
+	require.Equal(t, "resource", resourceValue)
 }


### PR DESCRIPTION
## Description of Changes
### Added
- The `Resource` field was added to Entry
- The `Identifier` helper was created to assist with writing to `Resource`

### Removed
- The `Tags` field was removed from Entry

### Changed
- The `host_metadata` operator now writes to an entry's `Resource` field, instead of Labels
- The `host_labeler` helper has been renamed `host_identifier`
- The `metadata` operator embeds the `Identifier` helper and supports writing to `Resource`
- Input operators embed the `Identifier` helper and support writing to `Resource`
- The `k8s_event` operator now supports the `write_to`, `labels`, and `resource` configuration options

## **Please check that the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Add a changelog entry (for non-trivial bug fixes / features)
- [x] CI passes
